### PR TITLE
Add media attachment toggle, fix location reset on record creation page

### DIFF
--- a/UI/assets/css/add-edit.css
+++ b/UI/assets/css/add-edit.css
@@ -12,7 +12,7 @@
   grid-template-columns: 1fr 1fr;
   grid-gap: 2rem;
 }
-.add-edit__form label {
+.add-edit__form label:not(.add-edit__media label) {
   display: block;
 }
 
@@ -27,7 +27,14 @@
   padding-left: 1rem;
   opacity: 0.8;
 }
-
+.add-edit__media {
+  margin-top: 1rem;
+}
+.add-edit__media * {
+  width: min-content;
+  margin-right: 1rem;
+  outline: none;
+}
 .add-edit__details {
   min-height: 15rem;
   min-width: 100%;
@@ -39,11 +46,11 @@
 .add-edit__location--clear {
   position: absolute;
   box-shadow: 0.15rem 0.15rem 0.3rem;
-  top: 0;
+  top: 3rem;
   right: 0.5rem;
   height: 50%;
+  width: 5rem;
   padding: 0.8rem;
-  transform: translateY(3.2rem);
   outline: none;
 }
 .add-edit__location--clear:hover {
@@ -65,3 +72,8 @@
 .full-width {
   grid-column: 1 / 3;
 }
+ @media screen and (max-width: 410px) {
+  .add-edit__media {
+    margin-top: 3.5rem;
+  }
+ }

--- a/UI/assets/js/create-edit.js
+++ b/UI/assets/js/create-edit.js
@@ -2,28 +2,37 @@ const recordForm = document.getElementById('add-edit--form');
 const locationInput = document.getElementById('add-edit-location');
 const coordDisplay = document.getElementById('add-edit-coords');
 const locationReset = document.getElementById('coords-reset');
+const mediaToggle = document.getElementById('add-edit-media-toggle');
 
 recordForm.addEventListener('submit', e => e.preventDefault());
 
-const updateCoords = ({ lng, lat }) => {
-  coordDisplay.value = `${lng()}, ${lat()}`;
-  coordDisplay.hidden = false;
-};
+const getCoords = ({ lng, lat }) => `${lng()}, ${lat()}`;
 
-const resetLocationFields = () => {
-  locationInput.value = '';
-  coordDisplay.value = '';
-  coordDisplay.hidden = true;
+const displayCoords = coordinateString => {
+  coordDisplay.value = coordinateString;
+  coordDisplay.hidden = false;
 };
 
 const liveUpdate = new google.maps.places.Autocomplete(locationInput);
 liveUpdate.addListener('place_changed', () => {
   const location = liveUpdate.getPlace();
   if (location.geometry) {
-    updateCoords(location.geometry.location);
+    const coordinateString = getCoords(location.geometry.location);
+    displayCoords(coordinateString);
   } else {
     alert(`Error: no geospatial coordinates availabe for "${location.name}"`);
   }
 });
 
+const resetLocationFields = () => {
+  locationInput.value = '';
+  coordDisplay.value = '';
+  coordDisplay.hidden = true;
+};
 locationReset.addEventListener('click', () => resetLocationFields());
+
+mediaToggle.addEventListener('change', () =>
+  recordForm
+    .querySelectorAll('.hidden')
+    .forEach(element => element.classList.toggle('gone'))
+);

--- a/UI/views/add-edit.html
+++ b/UI/views/add-edit.html
@@ -27,7 +27,12 @@
       <section class="wrapper">
         <div class="bg-grey">
           <h1 class="add-edit__mode">Add new record</h1>
-          <form class="add-edit__form" id="add-edit--form" enctype="multipart/form-data" method="POST">
+          <form
+            class="add-edit__form"
+            id="add-edit--form"
+            enctype="multipart/form-data"
+            method="POST"
+          >
             <div>
               <label for="add-edit-type">Type</label>
               <select
@@ -39,6 +44,14 @@
                 <option value="red-flag">red flag</option>
                 <option value="intervention">Intervention</option>
               </select>
+            </div>
+            <div class="add-edit__media">
+              <label for="add-edit-media-toggle">Photos/Video:</label>
+              <input
+                class="add-edit__media-toggle"
+                type="checkbox"
+                id="add-edit-media-toggle"
+              />
             </div>
             <div class="full-width">
               <label for="add-edit-title">Title</label>
@@ -66,7 +79,9 @@
                 name="add-edit-location"
                 placeholder="Start typing a location"
               />
-              <button class="add-edit__location--clear " id="coords-reset">Clear</button>
+              <button class="add-edit__location--clear" id="coords-reset">
+                Clear
+              </button>
             </div>
             <input
               class="add-edit__coords full-width"
@@ -76,7 +91,7 @@
               disabled
               hidden
             />
-            <div>
+            <div class="hidden gone">
               <label for="add-edit-pictures">Pictures</label>
               <input
                 class="add-edit__pictures"
@@ -88,7 +103,7 @@
                 capture="environment"
               />
             </div>
-            <div>
+            <div class="hidden gone">
               <label for="add-edit-videos">Videos</label>
               <input
                 class="add-edit__videos"


### PR DESCRIPTION
**What does this PR do?**
- Makes media attachment optional on the record creation page
- fix location reset button on the record creation page


**Description of Task to be completed?**
- Create media attachment toggle
- Fix location reset button

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-ui-templates`
- Open index.html in the browser
- Follow the `create record` link on the navbar.

**Any background context you want to provide?**
N/A

**What are the relevant pivotal tracker stories?**
162238515
162235616

Screenshots (if appropriate)


Questions: