### PR TITLE
#162289641 Client can create new red-flag record

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "debug": "^4.1.0",
     "dotenv": "^6.1.0",
-    "express": "^4.16.4"
+    "express": "^4.16.4",
+    "morgan": "^1.9.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,0 +1,15 @@
+class RecDB extends Array {
+  commit(record) {
+    const recordToSave = {
+      ...record,
+      id: this.length + 1,
+      createdOn: Date.now(),
+    };
+    this.push(recordToSave);
+    return Promise.resolve(this.pop());
+  }
+}
+
+const recordStore = new RecDB();
+
+export default recordStore;

--- a/src/helpers/errorHelper.js
+++ b/src/helpers/errorHelper.js
@@ -1,0 +1,15 @@
+export const missingFieldsMessage = textParts =>
+  textParts.length > 1
+    ? `missing required ${textParts
+        .slice(0, -1)
+        .join(',')} and ${textParts.slice(-1)} fields`
+    : `missing required ${textParts[0]} field`;
+
+export default (
+  response,
+  errors = ['Oops an unknown error occured. Please try again'],
+  code = 500
+) =>
+  response.status(code).json({
+    errors: errors instanceof Array ? errors : [errors],
+  });

--- a/src/helpers/jsonParse.js
+++ b/src/helpers/jsonParse.js
@@ -1,0 +1,9 @@
+export default arg => {
+  let parsed;
+  try {
+    parsed = JSON.parse(arg);
+  } catch (e) {
+    return null;
+  }
+  return parsed;
+};

--- a/src/helpers/successResponse.js
+++ b/src/helpers/successResponse.js
@@ -1,0 +1,4 @@
+export default (response, data = [], code = 200) =>
+  response.status(code).json({
+    data: data instanceof Array ? data : [data],
+  });

--- a/src/middlewares/records/strictRecordType.js
+++ b/src/middlewares/records/strictRecordType.js
@@ -1,0 +1,18 @@
+import handleError from '../../helpers/errorHelper';
+
+export default type => (req, res, next) => {
+  const { body } = req;
+
+  switch (type) {
+    case 'red-flag':
+      if (body.type !== type) {
+        handleError(res, 'invalid record type', 400);
+      } else {
+        next();
+      }
+
+      break;
+    default:
+      break;
+  }
+};

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -1,0 +1,109 @@
+import handleError, { missingFieldsMessage } from '../helpers/errorHelper';
+import jsonParse from '../helpers/jsonParse';
+
+export const validTypes = {
+  title: 'string',
+  type: 'string',
+  comment: 'string',
+  status: ['under investigation', 'resolved', 'rejected', 'draft'],
+  location: 'string',
+};
+
+export const checkRequired = checkWhat => (req, res, next) => {
+  const { body } = req;
+  const missingFields = [];
+
+  switch (checkWhat) {
+    case 'record':
+      missingFields.push(
+        ...['type', 'title', 'comment'].filter(
+          param => body[param] === undefined
+        )
+      );
+
+      break;
+    default:
+      break;
+  }
+
+  if (missingFields.length > 0) {
+    return handleError(res, missingFieldsMessage(missingFields), 400);
+  }
+  return next();
+};
+
+export const verifyRequestTypes = verifyWhat => (req, res, next) => {
+  const { title, type, comment, status, location } = req.body;
+  const recordRequestParams = { title, type, comment, status, location };
+  const errors = [];
+  let long;
+  let lat;
+
+  if (verifyWhat === 'record') {
+    Object.keys(recordRequestParams).forEach(param => {
+      switch (param) {
+        case 'status':
+          if (recordRequestParams[param] === undefined || null) {
+            break;
+          }
+
+          if (
+            typeof recordRequestParams[param] !== 'string' ||
+            !validTypes.status.includes(recordRequestParams[param])
+          ) {
+            errors.push(
+              `cannot parse invalid status "${recordRequestParams[param]}"`
+            );
+          }
+
+          break;
+        case 'location':
+          if (recordRequestParams[param] === undefined || null) {
+            break;
+          }
+
+          if (typeof recordRequestParams[param] !== typeof validTypes[param]) {
+            errors.push(
+              `cannot parse invalid Location "${
+                recordRequestParams[param]
+              }" - location must be a comma separated string of numeric longitude and latitude`
+            );
+          } else {
+            [long, lat] = recordRequestParams[param].split(',');
+            if (
+              typeof long === 'undefined' ||
+              typeof jsonParse(long.trim()) !== 'number' ||
+              (typeof lat === 'undefined' ||
+                typeof jsonParse(lat.trim()) !== 'number')
+            ) {
+              errors.push(
+                `cannot parse invalid Location "${
+                  recordRequestParams[param]
+                }" - location must be a comma separated string of numeric longitude and latitude`
+              );
+            }
+          }
+
+          break;
+        default:
+          if (recordRequestParams[param] === undefined || null) {
+            break;
+          }
+
+          if (typeof recordRequestParams[param] !== typeof validTypes[param]) {
+            errors.push(
+              `invalid ${param} "${
+                recordRequestParams[param]
+              }" - ${param} should be a ${validTypes[param]}`
+            );
+          }
+          break;
+      }
+    });
+  }
+
+  if (errors.length > 0) {
+    return handleError(res, errors, 422);
+  }
+  return next();
+};

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -1,0 +1,28 @@
+import recordStore from '../config/db';
+
+class Record {
+  constructor({ title, type, createdBy, comment, location, images, videos }) {
+    this.title = title;
+    this.type = type;
+    this.createdBy = createdBy;
+    this.comment = comment;
+    this.location = location;
+    this.images = images;
+    this.videos = videos;
+    this.status = 'under investigation';
+  }
+
+  set setStatus(status) {
+    this.status = status;
+  }
+
+  save() {
+    return recordStore.commit(this);
+  }
+}
+
+export class RedFlag extends Record {
+  constructor({ ...args }) {
+    super({ type: 'red-flag', ...args });
+  }
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,9 @@
+import recordRouter from './records/index';
+
+const ROOT_URL = '/api/v1';
+
+const router = app => {
+  app.use(ROOT_URL, recordRouter);
+};
+
+export default router;

--- a/src/routes/records/index.js
+++ b/src/routes/records/index.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import redFlagController from './redFlagController';
+import strictRecordType from '../../middlewares/records/strictRecordType';
+import {
+  checkRequired,
+  verifyRequestTypes,
+} from '../../middlewares/sanitizeRequest';
+
+const router = new Router();
+
+router.post(
+  '/red-flags',
+  checkRequired('record'),
+  verifyRequestTypes('record'),
+  strictRecordType('red-flag'),
+  redFlagController.createRecord
+);
+
+export default router;

--- a/src/routes/records/redFlagController.js
+++ b/src/routes/records/redFlagController.js
@@ -1,0 +1,15 @@
+import { RedFlag } from '../../models/records';
+import successResponse from '../../helpers/successResponse';
+
+const createRecord = (req, res) => {
+  const { title, comment, location } = req.body;
+
+  const newRedFlag = new RedFlag({ title, comment, location });
+  newRedFlag
+    .save()
+    .then(({ id }) =>
+      successResponse(res, { id, message: `Created red-flag record` }, 201)
+    );
+};
+
+export default { createRecord };

--- a/src/server.js
+++ b/src/server.js
@@ -1,13 +1,23 @@
 import express from 'express';
 import debug from 'debug';
+import morgan from 'morgan';
 import env from './config/envConf';
+import routes from './routes/index';
 
 const app = express();
 const logger = debug('iReporter::server:');
 const { PORT } = env;
 
+if (env.NODE_ENV === `production`) {
+  app.use(morgan('combined'));
+} else {
+  app.use(morgan('dev'));
+}
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+routes(app);
 
 app.listen(PORT, () => logger(`started api server on ${PORT}`));
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,12 @@
+export const sampleRedFlagToAdd = {
+  title: 'funny business',
+  type: 'red-flag',
+  location: '101.68685499999992,3.139003',
+  comment: 'I smell something fishy',
+};
+
+export const sampleInvalidRedFlag = {
+  type: 'red-flag',
+  location: '101.68685499999992,3.139003',
+  comment: 'I smell something fishy',
+};

--- a/test/index.js
+++ b/test/index.js
@@ -2,11 +2,13 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import debug from 'debug';
 import server from '../src/server';
-import isAllWell from './isallwellintestland';
+import records from './records';
 
 chai.use(chaiHttp);
+
 const { expect } = chai;
 const logger = debug('iReporter::test:');
-const testArgs = { server, chai, expect, logger };
+const ROOT_URL = `/api/v1`;
+const testArgs = { server, chai, expect, ROOT_URL, logger };
 
-isAllWell(testArgs);
+records(testArgs);

--- a/test/isallwellintestland.js
+++ b/test/isallwellintestland.js
@@ -1,7 +1,0 @@
-export default ({ expect, logger }) => {
-  logger('testing to see if setup worked...... (setup? set-up??)');
-
-  it('expect two instances of the exact same string to be equal', async () => {
-    expect('hello, i am iReporter').eq('hello, i am iReporter');
-  });
-};

--- a/test/records.js
+++ b/test/records.js
@@ -1,0 +1,51 @@
+import { sampleRedFlagToAdd, sampleInvalidRedFlag } from './helpers';
+
+export default ({ server, chai, expect, ROOT_URL, logger }) => {
+  describe('Red-flag records', () => {
+    describe('Creation', () => {
+      it('Records missing required field returns error response', () => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/red-flags`)
+          .send(sampleInvalidRedFlag)
+          .end((err, { body, status }) => {
+            logger(body);
+            expect(status).eq(400);
+            expect(body.errors[0]).eq('missing required title field');
+          });
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/red-flags`)
+          .send({ ...sampleInvalidRedFlag, ...{ comment: undefined } })
+          .end((err, { body, status }) => {
+            expect(status).eq(400);
+            expect(body.errors[0]).eq(
+              'missing required title and comment fields'
+            );
+          });
+      });
+
+      it('mismatched request data types should return error', () => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/red-flags`)
+          .send({ ...sampleRedFlagToAdd, ...{ location: 'knowhere' } })
+          .end((err, { body, status }) => {
+            expect(status).eq(422);
+            expect(body.errors[0]).to.be.a('string');
+          });
+      });
+
+      it('Creates a valid red-flag record', () => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/red-flags`)
+          .send(sampleRedFlagToAdd)
+          .end((err, { body, status }) => {
+            expect(status).eq(201);
+            expect(body.data[0].message).eq('Created red-flag record');
+          });
+      });
+    });
+  });
+};


### PR DESCRIPTION
**What does this PR do?**

Sets up the red-flag record creation endpoint(`POST`) at `/api/v1/red-flags` 

**Description of Task to be completed?**
- Add tests for red-flag record creation
- Model data to fit spec and  setup ephemeral storage using data structures
- Add middlewares and helpers to sanitize and validate request body
- Add request logger to view dev request logs
- Implement record creation route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-red-flag-creation`
- run `npm run devstart`
 test red-flag record creation by sending post requests `${ROOT_URL}/red-flags` 
where `${ROOT_URL}` is the API prefix URL on your local machine

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162289641

Screenshots (if appropriate)

N/A

Questions:

N/A