### PR TITLE
#162322068 Client can fetch all red-flag records

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,4 +1,12 @@
 class RecDB extends Array {
+  clear() {
+    this.length = 0;
+  }
+
+  fetch() {
+    return this;
+  }
+
   commit(record) {
     const recordToSave = {
       ...record,
@@ -6,10 +14,8 @@ class RecDB extends Array {
       createdOn: Date.now(),
     };
     this.push(recordToSave);
-    return Promise.resolve(this.pop());
+    return Promise.resolve(this.slice(-1));
   }
 }
 
-const recordStore = new RecDB();
-
-export default recordStore;
+export const recordStore = new RecDB();

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -1,4 +1,4 @@
-import recordStore from '../config/db';
+import { recordStore } from '../config/db';
 
 class Record {
   constructor({ title, type, createdBy, comment, location, images, videos }) {
@@ -24,5 +24,12 @@ class Record {
 export class RedFlag extends Record {
   constructor({ ...args }) {
     super({ type: 'red-flag', ...args });
+  }
+
+  static getAll() {
+    const allRecords = recordStore.fetch();
+    return Promise.resolve(
+      allRecords.filter(record => record.type === 'red-flag')
+    );
   }
 }

--- a/src/routes/records/index.js
+++ b/src/routes/records/index.js
@@ -15,5 +15,6 @@ router.post(
   strictRecordType('red-flag'),
   redFlagController.createRecord
 );
+router.get('/red-flags', redFlagController.fetchAllRecords);
 
 export default router;

--- a/src/routes/records/redFlagController.js
+++ b/src/routes/records/redFlagController.js
@@ -1,5 +1,6 @@
 import { RedFlag } from '../../models/records';
 import successResponse from '../../helpers/successResponse';
+import handleError from '../../helpers/errorHelper';
 
 const createRecord = (req, res) => {
   const { title, comment, location } = req.body;
@@ -12,4 +13,12 @@ const createRecord = (req, res) => {
     );
 };
 
-export default { createRecord };
+const fetchAllRecords = (req, res) => {
+  RedFlag.getAll().then(redFlagRecords =>
+    redFlagRecords.length > 0
+      ? successResponse(res, redFlagRecords, 200)
+      : handleError(res, 'No red-flag records found', 404)
+  );
+};
+
+export default { createRecord, fetchAllRecords };


### PR DESCRIPTION
**What does this PR do?**

Sets up the "all red-flag" record fetching endpoint(`GET`) at `/api/v1/red-flags` 

**Description of Task to be completed?**
- Add tests for fetching all red-flag records
- Implement record creation route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-fetch-all-red-flags`
- run `npm run devstart`
 test red-flag record fetching by creating some records then sending get requests `${ROOT_URL}/red-flags` 
where `${ROOT_URL}` is the API prefix URL on your local machine

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162322068

Screenshots (if appropriate)

N/A

Questions:

N/A