### PR TITLE
#162326491 Client can fetch specific red-flag record by ID

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -14,7 +14,7 @@ class RecDB extends Array {
       createdOn: Date.now(),
     };
     this.push(recordToSave);
-    return Promise.resolve(this.slice(-1));
+    return Promise.resolve(...this.slice(-1));
   }
 }
 

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -2,11 +2,11 @@ import handleError, { missingFieldsMessage } from '../helpers/errorHelper';
 import jsonParse from '../helpers/jsonParse';
 
 export const validTypes = {
-  title: 'string',
-  type: 'string',
-  comment: 'string',
+  title: String(),
+  type: String(),
+  comment: String(),
   status: ['under investigation', 'resolved', 'rejected', 'draft'],
-  location: 'string',
+  location: String(),
 };
 
 export const checkRequired = checkWhat => (req, res, next) => {

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -12,6 +12,18 @@ class Record {
     this.status = 'under investigation';
   }
 
+  static getAll(type) {
+    const allRecords = recordStore.fetch();
+    return Promise.resolve(allRecords.filter(record => record.type === type));
+  }
+
+  static getOneByID(id, type) {
+    const theOne = recordStore
+      .fetch()
+      .filter(record => record.type === type && record.id === id);
+    return Promise.resolve(theOne);
+  }
+
   set setStatus(status) {
     this.status = status;
   }
@@ -27,9 +39,10 @@ export class RedFlag extends Record {
   }
 
   static getAll() {
-    const allRecords = recordStore.fetch();
-    return Promise.resolve(
-      allRecords.filter(record => record.type === 'red-flag')
-    );
+    return super.getAll('red-flag');
+  }
+
+  static getOneByID(id) {
+    return super.getOneByID(id, 'red-flag');
   }
 }

--- a/src/routes/records/index.js
+++ b/src/routes/records/index.js
@@ -16,5 +16,6 @@ router.post(
   redFlagController.createRecord
 );
 router.get('/red-flags', redFlagController.fetchAllRecords);
+router.get('/red-flags/:id', redFlagController.fetchRecordByID);
 
 export default router;

--- a/src/routes/records/redFlagController.js
+++ b/src/routes/records/redFlagController.js
@@ -1,6 +1,7 @@
 import { RedFlag } from '../../models/records';
 import successResponse from '../../helpers/successResponse';
 import handleError from '../../helpers/errorHelper';
+import jsonParse from '../../helpers/jsonParse';
 
 const createRecord = (req, res) => {
   const { title, comment, location } = req.body;
@@ -21,4 +22,13 @@ const fetchAllRecords = (req, res) => {
   );
 };
 
-export default { createRecord, fetchAllRecords };
+const fetchRecordByID = (req, res) => {
+  const { id } = req.params;
+  RedFlag.getOneByID(jsonParse(id)).then(record =>
+    record.length > 0
+      ? successResponse(res, record)
+      : handleError(res, `No order found with id '${id}'`, 404)
+  );
+};
+
+export default { createRecord, fetchAllRecords, fetchRecordByID };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,3 +1,5 @@
+export const ID = { nonExistent: 12000, valid: 1 };
+
 export const sampleRedFlagToAdd = {
   title: 'funny business',
   type: 'red-flag',

--- a/test/records.js
+++ b/test/records.js
@@ -1,5 +1,6 @@
 import { recordStore } from '../src/config/db';
-import { sampleRedFlagToAdd, sampleInvalidRedFlag } from './helpers';
+import { RedFlag } from '../src/models/records';
+import { ID, sampleRedFlagToAdd, sampleInvalidRedFlag } from './helpers';
 
 export default ({ server, chai, expect, ROOT_URL }) => {
   describe('Red-flag records', () => {
@@ -61,14 +62,37 @@ export default ({ server, chai, expect, ROOT_URL }) => {
       });
 
       it('Should fetch all available red-flag records', () => {
-        [...Array(3)].forEach(() => recordStore.commit(sampleRedFlagToAdd));
+        new RedFlag(sampleRedFlagToAdd).save();
         chai
           .request(server)
-          .get(`${ROOT_URL}/red-flags`)
+          .get(`${ROOT_URL}/red-flags/`)
           .end((err, { body, status }) => {
             expect(status).eq(200);
             expect(body.data).to.be.an.instanceof(Array);
-            expect(body.data[0]).to.be.a('object');
+            expect(body.data[0]).to.be.an('object');
+          });
+      });
+
+      it('Returns a not found response when specific record ID does not exist', () => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/red-flags/${ID.nonExistent}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors[0]).eq(
+              `No order found with id '${ID.nonExistent}'`
+            );
+          });
+      });
+
+      it('Should fetch a specific red-flag record by ID', () => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/red-flags/${ID.valid}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data).to.be.an.instanceof(Array);
+            expect(body.data[0]).to.be.an('object');
           });
       });
     });


### PR DESCRIPTION
**What does this PR do?**

Sets up the "specific red-flag" record fetching endpoint(`GET`) at `/api/v1/red-flags/:id` 

**Description of Task to be completed?**
- Add tests for fetching a specific red-flag record by id
- Implement record specific red-flag record fetching route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-fetch-red-flag-by-id`
- run `npm run devstart`
- Create some records
 test red-flag record fetching by sending get requests `${ROOT_URL}/red-flags/:id` 
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the record to fetch

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162326491

Screenshots (if appropriate)

N/A

Questions:

N/A