### PR TITLE
Client can edit saved red-flag record comment/location

### DIFF
--- a/src/middlewares/records/loadOneByID.js
+++ b/src/middlewares/records/loadOneByID.js
@@ -1,0 +1,22 @@
+import { RedFlag } from '../../models/records';
+import jsonParse from '../../helpers/jsonParse';
+import handleError from '../../helpers/errorHelper';
+
+export default ({ what }) => (req, res, next) => {
+  const { id } = req.params;
+  switch (what) {
+    case 'red-flag':
+      RedFlag.getOneByID(jsonParse(id)).then(record =>
+        record
+          ? (() => {
+              req.record = record;
+              next();
+            })()
+          : handleError(res, `No order found with id '${id}'`, 404)
+      );
+      break;
+
+    default:
+      break;
+  }
+};

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -14,13 +14,18 @@ export const checkRequired = checkWhat => (req, res, next) => {
   const missingFields = [];
 
   switch (checkWhat) {
+    case 'comment':
+      if (!body.comment) missingFields.push('comment');
+      break;
+    case 'location':
+      if (!body.location) missingFields.push('location');
+      break;
     case 'record':
       missingFields.push(
         ...['type', 'title', 'comment'].filter(
           param => body[param] === undefined
         )
       );
-
       break;
     default:
       break;

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -21,7 +21,12 @@ class Record {
     const theOne = recordStore
       .fetch()
       .filter(record => record.type === type && record.id === id);
-    return Promise.resolve(theOne);
+    return Promise.resolve(...theOne);
+  }
+
+  static patch(type, id, patch, prop) {
+    recordStore[id - 1][prop] = patch;
+    return Record.getOneByID(id, type);
   }
 
   set setStatus(status) {
@@ -44,5 +49,9 @@ export class RedFlag extends Record {
 
   static getOneByID(id) {
     return super.getOneByID(id, 'red-flag');
+  }
+
+  static patch(id, patch, prop) {
+    return super.patch('red-flag', id, patch, prop);
   }
 }

--- a/src/routes/records/index.js
+++ b/src/routes/records/index.js
@@ -5,17 +5,36 @@ import {
   checkRequired,
   verifyRequestTypes,
 } from '../../middlewares/sanitizeRequest';
+import loadOneByID from '../../middlewares/records/loadOneByID';
 
 const router = new Router();
 
 router.post(
   '/red-flags',
   checkRequired('record'),
-  verifyRequestTypes('record'),
   strictRecordType('red-flag'),
+  verifyRequestTypes('record'),
   redFlagController.createRecord
 );
 router.get('/red-flags', redFlagController.fetchAllRecords);
-router.get('/red-flags/:id', redFlagController.fetchRecordByID);
+router.get(
+  '/red-flags/:id',
+  loadOneByID({ what: 'red-flag' }),
+  redFlagController.fetchRecordByID
+);
+router.patch(
+  '/red-flags/:id/comment',
+  checkRequired('comment'),
+  loadOneByID({ what: 'red-flag' }),
+  verifyRequestTypes('record'),
+  redFlagController.updateComment
+);
+router.patch(
+  '/red-flags/:id/location',
+  checkRequired('location'),
+  loadOneByID({ what: 'red-flag' }),
+  verifyRequestTypes('record'),
+  redFlagController.updateLocation
+);
 
 export default router;

--- a/src/routes/records/redFlagController.js
+++ b/src/routes/records/redFlagController.js
@@ -1,7 +1,6 @@
 import { RedFlag } from '../../models/records';
 import successResponse from '../../helpers/successResponse';
 import handleError from '../../helpers/errorHelper';
-import jsonParse from '../../helpers/jsonParse';
 
 const createRecord = (req, res) => {
   const { title, comment, location } = req.body;
@@ -22,13 +21,38 @@ const fetchAllRecords = (req, res) => {
   );
 };
 
-const fetchRecordByID = (req, res) => {
-  const { id } = req.params;
-  RedFlag.getOneByID(jsonParse(id)).then(record =>
-    record.length > 0
-      ? successResponse(res, record)
-      : handleError(res, `No order found with id '${id}'`, 404)
-  );
-};
+const fetchRecordByID = ({ record }, res) => successResponse(res, record);
 
-export default { createRecord, fetchAllRecords, fetchRecordByID };
+const updateComment = ({ body, record }, res) =>
+  record.comment !== body.comment
+    ? RedFlag.patch(record.id, body.comment, 'comment').then(({ id }) =>
+        successResponse(res, {
+          id,
+          message: 'Updated red-flag record’s comment',
+        })
+      )
+    : successResponse(res, {
+        id: record.id,
+        message: 'Comment unchanged, nothing to update',
+      });
+
+const updateLocation = ({ body, record }, res) =>
+  record.location !== body.location
+    ? RedFlag.patch(record.id, body.location, 'location').then(({ id }) =>
+        successResponse(res, {
+          id,
+          message: 'Updated red-flag record’s location',
+        })
+      )
+    : successResponse(res, {
+        id: record.id,
+        message: 'Location unchanged, nothing to update',
+      });
+
+export default {
+  createRecord,
+  fetchAllRecords,
+  fetchRecordByID,
+  updateComment,
+  updateLocation,
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,10 @@
 export const ID = { nonExistent: 12000, valid: 1 };
 
+export const recordPatches = {
+  comment: 'lorem ipsum dolor sit amet',
+  location: '-94.68589980000002, 46.729553',
+};
+
 export const sampleRedFlagToAdd = {
   title: 'funny business',
   type: 'red-flag',

--- a/test/records.js
+++ b/test/records.js
@@ -1,6 +1,11 @@
 import { recordStore } from '../src/config/db';
 import { RedFlag } from '../src/models/records';
-import { ID, sampleRedFlagToAdd, sampleInvalidRedFlag } from './helpers';
+import {
+  ID,
+  recordPatches,
+  sampleRedFlagToAdd,
+  sampleInvalidRedFlag,
+} from './helpers';
 
 export default ({ server, chai, expect, ROOT_URL }) => {
   describe('Red-flag records', () => {
@@ -49,7 +54,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
       });
     });
 
-    describe('Fetching all', () => {
+    describe('Fetching', () => {
       it('Returns a not found response when no records exist', () => {
         recordStore.clear();
         chai
@@ -93,6 +98,68 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(status).eq(200);
             expect(body.data).to.be.an.instanceof(Array);
             expect(body.data[0]).to.be.an('object');
+          });
+      });
+    });
+
+    describe('Updating', () => {
+      it('Should not update record with non-existent id', () => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/${ID.nonExistent}/comment`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body).to.have.property('errors');
+            expect(body).to.not.have.property('data');
+          });
+      });
+
+      it('Should succesfully update location of record with valid id', () => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/${ID.valid}/location`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+          });
+      });
+
+      it('Should return success when location patch equals original', () => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/${ID.valid}/location`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+          });
+      });
+
+      it('Should succesfully update comment of record with valid id', () => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/${ID.valid}/comment`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+          });
+      });
+
+      it('Should return success when comment patch equals original', () => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/${ID.valid}/comment`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
           });
       });
     });


### PR DESCRIPTION
**What does this PR do?**

Sets up the  red-flag record comment and location updating endpoints(`PATCH`) at `/api/v1/red-flags/:id/location` and `/api/v1/red-flags/:id/comment` respectively

**Description of Task to be completed?**
- Add tests for updating a specific red-flag record location and comment
- Implement saved red-flag record comment/location data updates

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-update-red-flag`
- run `npm run devstart`
- Create some records
 test red-flag record updating by sending `PATCH` requests `${ROOT_URL}/red-flags/:id/comment` and `${ROOT_URL}/red-flags/:id/location`
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the record to update

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162327118
162326836

Screenshots (if appropriate)

N/A

Questions:

N/A