### PR TITLE
#162385457 Improve request parameter validation recipie 

### DIFF
--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -47,7 +47,8 @@ export const verifyRequestTypes = verifyWhat => (req, res, next) => {
   const isEmpty = stringParam => stringParam === '';
 
   if (verifyWhat === 'record') {
-    Object.keys(recordRequestParams).forEach(param => {
+    Object.keys(recordRequestParams).forEach(reqParam => {
+      const param = reqParam.trim();
       switch (param) {
         case 'status':
           if (recordRequestParams[param] === undefined) {
@@ -112,6 +113,9 @@ export const verifyRequestTypes = verifyWhat => (req, res, next) => {
             );
           }
           break;
+      }
+      if (req.body[param]) {
+        req.body[param] = req.body[param].trim();
       }
     });
   }

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -44,15 +44,18 @@ export const verifyRequestTypes = verifyWhat => (req, res, next) => {
   let long;
   let lat;
 
+  const isEmpty = stringParam => stringParam === '';
+
   if (verifyWhat === 'record') {
     Object.keys(recordRequestParams).forEach(param => {
       switch (param) {
         case 'status':
-          if (recordRequestParams[param] === undefined || null) {
+          if (recordRequestParams[param] === undefined) {
             break;
           }
 
           if (
+            isEmpty(recordRequestParams[param]) ||
             typeof recordRequestParams[param] !== 'string' ||
             !validTypes.status.includes(recordRequestParams[param])
           ) {
@@ -63,11 +66,14 @@ export const verifyRequestTypes = verifyWhat => (req, res, next) => {
 
           break;
         case 'location':
-          if (recordRequestParams[param] === undefined || null) {
+          if (recordRequestParams[param] === undefined) {
             break;
           }
 
-          if (typeof recordRequestParams[param] !== typeof validTypes[param]) {
+          if (
+            isEmpty(recordRequestParams[param]) ||
+            typeof recordRequestParams[param] !== typeof validTypes[param]
+          ) {
             errors.push(
               `cannot parse invalid Location "${
                 recordRequestParams[param]
@@ -91,15 +97,18 @@ export const verifyRequestTypes = verifyWhat => (req, res, next) => {
 
           break;
         default:
-          if (recordRequestParams[param] === undefined || null) {
+          if (recordRequestParams[param] === undefined) {
             break;
           }
 
-          if (typeof recordRequestParams[param] !== typeof validTypes[param]) {
+          if (
+            isEmpty(recordRequestParams[param]) ||
+            typeof recordRequestParams[param] !== typeof validTypes[param]
+          ) {
             errors.push(
-              `invalid ${param} "${
-                recordRequestParams[param]
-              }" - ${param} should be a ${validTypes[param]}`
+              `invalid ${param} - ${param} should be a valid non-empty ${typeof validTypes[
+                param
+              ]}`
             );
           }
           break;


### PR DESCRIPTION
**What does this PR do?**

Patches request validation module to enforce non-empty fields and trim unnecessary white space from `request.body` params

**Description of Task to be completed?**
- Enforce validation against empty fields
- Strip off excess whitespace on `request.body` params

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `bugfix-sanitize-request`
- Run `npm run devstart`
- Try creating a few records with empty fields and some with unnecessary whitespace
 - Records with empty fields should return an error response
 - Fields having extra whitespace get stripped of any unnecessary whitespace

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162385457

Screenshots (if appropriate)

N/A

Questions:

N/A