### PR TITLE
#162396528 Make API responses spec compliant

### DIFF
--- a/src/helpers/errorHelper.js
+++ b/src/helpers/errorHelper.js
@@ -11,5 +11,6 @@ export default (
   code = 500
 ) =>
   response.status(code).json({
+    status: code,
     errors: errors instanceof Array ? errors : [errors],
   });

--- a/src/helpers/successResponse.js
+++ b/src/helpers/successResponse.js
@@ -1,4 +1,4 @@
 export default (response, data = [], code = 200) =>
-  response.status(code).json({
-    data: data instanceof Array ? data : [data],
-  });
+  response
+    .status(code)
+    .json({ status: code, data: data instanceof Array ? data : [data] });

--- a/src/routes/records/redFlagController.js
+++ b/src/routes/records/redFlagController.js
@@ -1,6 +1,5 @@
 import { RedFlag } from '../../models/records';
 import successResponse from '../../helpers/successResponse';
-import handleError from '../../helpers/errorHelper';
 
 const createRecord = (req, res) => {
   const { title, comment, location } = req.body;
@@ -16,8 +15,8 @@ const createRecord = (req, res) => {
 const fetchAllRecords = (req, res) => {
   RedFlag.getAll().then(redFlagRecords =>
     redFlagRecords.length > 0
-      ? successResponse(res, redFlagRecords, 200)
-      : handleError(res, 'No red-flag records found', 404)
+      ? successResponse(res, redFlagRecords)
+      : successResponse(res)
   );
 };
 

--- a/test/records.js
+++ b/test/records.js
@@ -55,14 +55,14 @@ export default ({ server, chai, expect, ROOT_URL }) => {
     });
 
     describe('Fetching', () => {
-      it('Returns a not found response when no records exist', () => {
+      it('Returns an empty array when no records exist', () => {
         recordStore.clear();
         chai
           .request(server)
           .get(`${ROOT_URL}/red-flags`)
           .end((err, { body, status }) => {
-            expect(status).eq(404);
-            expect(body.errors[0]).eq('No red-flag records found');
+            expect(status).eq(200);
+            expect(body.data).to.be.an.instanceof(Array);
           });
       });
 


### PR DESCRIPTION
**What does this PR do?**
Reformats API response bodies to include a status property

**Description of Task to be completed?**
- Include a status property in response bodies
- Fix response when getting all records when none have been created

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `bugfix-response-format`
- Run `npm run devstart`
- Try making a few requests, the response formats should be like so:

``` 
// POST/PATCH/DELETE
{
 “status” : Integer,
 “data” : [{
   “id” : Integer, // red flag record primary key
   “message”: "message"
  }]
}

// GET 
{
 “status” : Integer,
 “data” : [{...}]
}
 ```

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162396528

Screenshots (if appropriate)

N/A

Questions:

N/A