### PR TITLE
#162454516  User can fetch all intervention records

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -14,7 +14,13 @@ const createRecord = (req, res) => {
   });
 };
 
+const fetchAllRecords = (req, res) =>
+  Intervention.getAll().then(({ rows }) =>
+    rows.length > 0 ? successResponse(res, rows) : successResponse(res)
+  );
+
 
 export default {
   createRecord,
+  fetchAllRecords,
 };

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -83,7 +83,7 @@ export class RedFlag extends Record {
 
 export class Intervention extends Record {
   constructor({ ...args }) {
-    super({ type: 'red-flag', ...args });
+    super({ type: 'intervention', ...args });
   }
 
   static getAll() {

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -50,5 +50,6 @@ router.post(
   verifyRequestTypes,
   interventionController.createRecord
 );
+router.get('/interventions', interventionController.fetchAllRecords);
 
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -1,4 +1,5 @@
 import { RedFlag } from '../src/models/records';
+import { Intervention } from '../src/models/records';
 import {
   ID,
   recordPatches,
@@ -80,6 +81,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
     describe('Fetching', () => {
       it('Should fetch all available red-flag records', async () => {
         await new RedFlag(sampleRedFlagToAdd).save();
+        await new RedFlag(sampleRedFlagToAdd).save();
         chai
           .request(server)
           .get(`${ROOT_URL}/red-flags/`)
@@ -121,6 +123,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .patch(`${ROOT_URL}/red-flags/${ID.nonExistent}/comment`)
           .send(recordPatches)
           .end((err, { body, status }) => {
+            console.log(body)
             expect(status).eq(404);
             expect(body).to.have.property('errors');
             expect(body).to.not.have.property('data');
@@ -253,6 +256,21 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .end((err, { body, status }) => {
             expect(status).eq(201);
             expect(body.data[0].message).eq('Created Intervention record');
+          });
+      });
+    });
+
+    describe('Fetching', () => {
+      it('Should fetch all available intervention records', async () => {
+        await new Intervention(sampleInterventionToAdd).save();
+        await new Intervention(sampleInterventionToAdd).save();
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/interventions/`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data).to.be.an.instanceof(Array);
+            expect(body.data[0]).to.be.an('object');
           });
       });
     });


### PR DESCRIPTION
**What does this PR do?**

Sets up the "all intervention" record fetching endpoint(`GET`) at `/api/v1/interventions` 

**Description of Task to be completed?**
- Add tests for fetching all intervention records
- Implement record fetching route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-get-all-interventions`
- run `npm run devstart`
 test red-flag record fetching by creating some records then sending `GET` requests `${ROOT_URL}/interventions` 
where `${ROOT_URL}` is the API prefix URL on your local machine

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162454516

Screenshots (if appropriate)

N/A

Questions:

N/A