### PR TITLE
#162454606 User can fetch one intervention by id

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -19,8 +19,10 @@ const fetchAllRecords = (req, res) =>
     rows.length > 0 ? successResponse(res, rows) : successResponse(res)
   );
 
+  const fetchRecordByID = ({ record }, res) => successResponse(res, record);
 
 export default {
   createRecord,
   fetchAllRecords,
+  fetchRecordByID,
 };

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -51,5 +51,10 @@ router.post(
   interventionController.createRecord
 );
 router.get('/interventions', interventionController.fetchAllRecords);
+router.get(
+  '/interventions/:id',
+  loadRecordByID('intervention'),
+  redFlagController.fetchRecordByID
+);
 
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -273,6 +273,29 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(body.data[0]).to.be.an('object');
           });
       });
+
+      it('Returns a not found response when specific record ID does not exist', () => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/interventions/${ID.nonExistent}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors[0]).eq(
+              `No record exists with id '${ID.nonExistent}'`
+            );
+          });
+      });
+
+      it('Should fetch a specific intervention record by ID', () => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/interventions/${ID.valid}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data).to.be.an.instanceof(Array);
+            expect(body.data[0]).to.be.an('object');
+          });
+      });
     });
   });
 };


### PR DESCRIPTION
**What does this PR do?**

Sets up the "specific intervention" record fetching endpoint(`GET`) at `/api/v1/interventions/:id` 

**Description of Task to be completed?**
- Add tests for fetching a specific red-flag record by id
- Implement record specific red-flag record fetching route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-intervention-by-id`
- run `npm run devstart`
- Create some records
 test red-flag record fetching by sending get requests `${ROOT_URL}/interventions/:id` 
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the order to fetch

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162454606

Screenshots (if appropriate)

N/A

Questions:

N/A