### PR TITLE
162454356 Users can create new  intervention record

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -1,0 +1,21 @@
+import { Intervention } from '../models/records';
+import successResponse from '../helpers/successResponse';
+
+const createRecord = (req, res) => {
+  const { title, comment, location } = req.body;
+
+  const newIntervention = new Intervention({ title, comment, location });
+  newIntervention.save().then(({ rows }) => {
+    successResponse(
+      res,
+      { ...rows[0], message: `Created Intervention record` },
+      201
+    );
+  });
+};
+
+
+
+export default {
+  createRecord,
+};

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -47,6 +47,12 @@ export const strictRecordType = type => (req, res, next) => {
       } else {
         next();
       }
+      case 'intervention':
+      if (body.type !== type) {
+        handleError(res, 'invalid record type', 400);
+      } else {
+        next();
+      }
 
       break;
     /* istanbul ignore next */

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -80,3 +80,25 @@ export class RedFlag extends Record {
     return super.delete(id);
   }
 }
+
+export class Intervention extends Record {
+  constructor({ ...args }) {
+    super({ type: 'intervention', ...args });
+  }
+
+  static getAll() {
+    return super.getAllByType('intervention');
+  }
+
+  static getOneByID(id) {
+    return super.getOneByID(id);
+  }
+
+  static patch(id, patch, prop) {
+    return super.patch(id, patch, prop);
+  }
+
+  static delete(id) {
+    return super.delete(id);
+  }
+}

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import redFlagController from '../controllers/redFlagController';
+import interventionController from '../controllers/interventionController';
 import {
   checkRequired,
   strictRecordType,
@@ -41,6 +42,14 @@ router.delete(
   '/red-flags/:id',
   loadRecordByID('red-flag'),
   redFlagController.deleteRecordByID
+);
+
+router.post(
+  '/interventions',
+  checkRequired('record'),
+  strictRecordType('intervention'),
+  verifyRequestTypes,
+  interventionController.createRecord
 );
 
 export default router;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,3 +17,15 @@ export const sampleInvalidRedFlag = {
   location: '101.68685499999992,3.139003',
   comment: 'I smell something fishy',
 };
+
+export const sampleInterventionToAdd = {
+  title: 'help needed',
+  type: 'intervention',
+  location: '101.68685499999992,3.139003',
+  comment: 'inverene please',
+};
+export const sampleInvalidIntervention = {
+  type: 'intervention',
+  location: '101.68685499999992,3.139003',
+  comment: 'inverene please',
+};

--- a/test/records.js
+++ b/test/records.js
@@ -5,6 +5,8 @@ import {
   recordPatches,
   sampleRedFlagToAdd,
   sampleInvalidRedFlag,
+  sampleInvalidIntervention,
+  sampleInterventionToAdd,
 } from './helpers';
 
 export default ({ server, chai, expect, ROOT_URL }) => {
@@ -200,4 +202,70 @@ export default ({ server, chai, expect, ROOT_URL }) => {
       });
     });
   });
+  describe('Intervention records', () => {
+    describe('Creation', () => {
+      it('Records missing required field returns error response', () => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send(sampleInvalidIntervention)
+          .end((err, { body, status }) => {
+            expect(status).eq(400);
+            expect(body.errors[0]).eq('missing required title field');
+          });
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send({ ...sampleInvalidIntervention, ...{ comment: undefined } })
+          .end((err, { body, status }) => {
+            expect(status).eq(400);
+            expect(body.errors[0]).eq(
+              'missing required title and comment fields'
+            );
+          });
+      });
+       it('mismatched request data types should return error', () => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send({ ...sampleInterventionToAdd, ...{ location: 'knowhere' } })
+          .end((err, { body, status }) => {
+            expect(status).eq(422);
+            expect(body.errors[0]).to.be.a('string');
+          });
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send({
+            ...sampleInterventionToAdd,
+            ...{ location: '', title: '' },
+          })
+          .end((err, { body, status }) => {
+            expect(status).eq(422);
+            expect(body.errors[0]).to.be.a('string');
+          });
+      });
+       it('should not create records for valid requests with the wrong recordtype', () => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send({ sampleInterventionToAdd, ...{ type: 'wrong' } })
+          .end((err, { body, status }) => {
+            expect(status).eq(400);
+            expect(typeof body.errors[0]).eq('string');
+          });
+      });
+       it('Creates a valid Intervention record', () => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send(sampleInterventionToAdd)
+          .end((err, { body, status }) => {
+            expect(status).eq(201);
+            expect(body.data[0].message).eq('Created Intervention record');
+          });
+      });
+    });
+  });
+
 };


### PR DESCRIPTION
**What does this PR do?**

Sets up the intervention record creation endpoint(`POST`) at `/api/v1/interventions` 

**Description of Task to be completed?**
- Update  data model
- Add tests forintervention record creation
- Implement record creation route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-red-flag-creation`
- run `npm run devstart`
 test red-flag record creation by sending post requests `${ROOT_URL}/interventions` 
where `${ROOT_URL}` is the API prefix URL on your local machine

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162454356

Screenshots (if appropriate)

N/A

Questions:

N/A