### PR TITLE
#162454516 Users can fetch all Intervention records

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -8,14 +8,18 @@ const createRecord = (req, res) => {
   newIntervention.save().then(({ rows }) => {
     successResponse(
       res,
-      { ...rows[0], message: `Created Intervention record` },
+      { ...rows[0].id, message: `Created Intervention record` },
       201
     );
   });
 };
 
-
+const fetchAllRecords = (req, res) =>
+  Intervention.getAll().then(({ rows }) =>
+    rows.length > 0 ? successResponse(res, rows) : successResponse(res)
+  );
 
 export default {
   createRecord,
+  fetchAllRecords,
 };

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -47,7 +47,8 @@ export const strictRecordType = type => (req, res, next) => {
       } else {
         next();
       }
-      case 'intervention':
+      break;
+    case 'intervention':
       if (body.type !== type) {
         handleError(res, 'invalid record type', 400);
       } else {

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -10,7 +10,6 @@ import loadRecordByID from '../middlewares/loadRecordByID';
 
 const router = new Router();
 
-
 router.post(
   '/red-flags',
   checkRequired('record'),
@@ -51,5 +50,7 @@ router.post(
   verifyRequestTypes,
   interventionController.createRecord
 );
+
+router.get('/interventions', interventionController.fetchAllRecords);
 
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -1,5 +1,5 @@
 import db from '../src/db/dbrc';
-import { RedFlag } from '../src/models/records';
+import { RedFlag, Intervention } from '../src/models/records';
 import {
   ID,
   recordPatches,
@@ -79,7 +79,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
     });
 
     describe('Fetching', () => {
-      it('Returns an empty array when no records exist', async() => {
+      it('Returns an empty array when no records exist', async () => {
         await db.blowAway();
         chai
           .request(server)
@@ -90,7 +90,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           });
       });
 
-      it('Should fetch all available red-flag records', async() => {
+      it('Should fetch all available red-flag records', async () => {
         await db.dbInit();
         await new RedFlag(sampleRedFlagToAdd).save();
         await new RedFlag(sampleRedFlagToAdd).save();
@@ -224,7 +224,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             );
           });
       });
-       it('mismatched request data types should return error', () => {
+      it('mismatched request data types should return error', () => {
         chai
           .request(server)
           .post(`${ROOT_URL}/interventions`)
@@ -245,7 +245,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(body.errors[0]).to.be.a('string');
           });
       });
-       it('should not create records for valid requests with the wrong recordtype', () => {
+      it('should not create records for valid requests with the wrong recordtype', () => {
         chai
           .request(server)
           .post(`${ROOT_URL}/interventions`)
@@ -255,7 +255,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(typeof body.errors[0]).eq('string');
           });
       });
-       it('Creates a valid Intervention record', () => {
+      it('Creates a valid Intervention record', () => {
         chai
           .request(server)
           .post(`${ROOT_URL}/interventions`)
@@ -265,7 +265,21 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(body.data[0].message).eq('Created Intervention record');
           });
       });
+
+      describe('Fetching', () => {
+        it('Should fetch all available intervention records', async () => {
+          await new Intervention(sampleInterventionToAdd).save();
+          await new Intervention(sampleInterventionToAdd).save();
+          chai
+            .request(server)
+            .get(`${ROOT_URL}/interventions/`)
+            .end((err, { body, status }) => {
+              expect(status).eq(200);
+              expect(body.data).to.be.an.instanceof(Array);
+              expect(body.data[0]).to.be.an('object');
+            });
+        });
+      });
     });
   });
-
 };


### PR DESCRIPTION
**What does this PR do?**

Sets up the "all intervention" record fetching endpoint(`GET`) at `/api/v1/interventions` 

**Description of Task to be completed?**
- Add tests for fetching all intervention records
- Implement record fetching route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-get-all-interventions`
- run `npm run devstart`
 test red-flag record fetching by creating some records then sending `GET` requests `${ROOT_URL}/interventions` 
where `${ROOT_URL}` is the API prefix URL on your local machine

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

162454516

Screenshots (if appropriate)

N/A

Questions:

N/A