### PR TITLE
#162531543 Users can create new intervention record

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -1,0 +1,19 @@
+import { Intervention } from '../models/records';
+import successResponse from '../helpers/successResponse';
+
+const createRecord = (req, res) => {
+  const { title, comment, location } = req.body;
+
+  const newIntervention = new Intervention({ title, comment, location });
+  newIntervention.save().then(({ rows }) => {
+    successResponse(
+      res,
+      { ...rows[0], message: `Created Intervention record` },
+      201
+    );
+  });
+};
+
+export default {
+  createRecord,
+};

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -54,6 +54,7 @@ export const strictRecordType = type => (req, res, next) => {
   const { body } = req;
 
   switch (type) {
+    case 'intervention':
     case 'red-flag':
       if (body.type !== type) {
         handleError(res, 'invalid record type', 400);

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -80,3 +80,25 @@ export class RedFlag extends Record {
     return super.delete(id);
   }
 }
+
+export class Intervention extends Record {
+  constructor({ ...args }) {
+    super({ type: 'intervention', ...args });
+  }
+
+  static getAll() {
+    return super.getAllByType('intervention');
+  }
+
+  static getOneByID(id) {
+    return super.getOneByID(id);
+  }
+
+  static patch(id, patch, prop) {
+    return super.patch(id, patch, prop);
+  }
+
+  static delete(id) {
+    return super.delete(id);
+  }
+}

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import interventionController from '../controllers/interventionController';
 import redFlagController from '../controllers/redFlagController';
 import {
   checkRequired,
@@ -8,7 +9,6 @@ import {
 import loadRecordByID from '../middlewares/loadRecordByID';
 
 const router = new Router();
-
 
 router.post(
   '/red-flags',
@@ -41,6 +41,16 @@ router.delete(
   '/red-flags/:id',
   loadRecordByID('red-flag'),
   redFlagController.deleteRecordByID
+);
+
+/* interventions */
+
+router.post(
+  '/interventions',
+  checkRequired('record'),
+  strictRecordType('intervention'),
+  verifyRequestTypes,
+  interventionController.createRecord
 );
 
 export default router;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -18,6 +18,13 @@ export const sampleInvalidRedFlag = {
   comment: 'I smell something fishy',
 };
 
+export const sampleInterventionToAdd = {
+  type: 'intervention',
+  location: '50.68685499999992,3.89',
+  title: 'need intervention',
+  comment: 'more on the state of the nations roads',
+};
+
 export const sampleInvalidUser = {
   username: 'rollo',
   password: 'weaksauce',

--- a/test/records.js
+++ b/test/records.js
@@ -5,6 +5,7 @@ import {
   recordPatches,
   sampleRedFlagToAdd,
   sampleInvalidRedFlag,
+  sampleInterventionToAdd,
 } from './helpers';
 
 export default ({ server, chai, expect, ROOT_URL }) => {
@@ -195,6 +196,34 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(status).eq(200);
             expect(body.data).is.an.instanceof(Array);
             expect(body.data[0]).to.have.property('message');
+          });
+      });
+    });
+  });
+
+  describe('Interventions', () => {
+    describe('Creation', () => {
+      it('should not create records for valid requests with the wrong recordtype', done => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send({ ...sampleInterventionToAdd, ...{ type: 'red-flag' } })
+          .end((err, { body, status }) => {
+            expect(status).eq(400);
+            expect(typeof body.errors[0]).eq('string');
+            done();
+          });
+      });
+
+      it('Creates a valid intervention record', done => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/interventions`)
+          .send(sampleInterventionToAdd)
+          .end((err, { body, status }) => {
+            expect(status).eq(201);
+            expect(body.data[0].message).eq('Created Intervention record');
+            done();
           });
       });
     });


### PR DESCRIPTION
**What does this PR do?**

Sets up the intervention record creation endpoint(`POST`) at `/api/v1/interventions` 

**Description of Task to be completed?**
- Update  data model
- Add tests for intervention record creation
- Implement record creation route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-create-intervention-162531543`
- run `npm run devstart`
 test red-flag record creation by sending post requests `${ROOT_URL}/interventions` 
where `${ROOT_URL}` is the API prefix URL on your local machine

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162531543](https://www.pivotaltracker.com/story/show/162531543)

Screenshots (if appropriate)

N/A

Questions:

N/A