### PR TITLE
#162531544 Users can fetch all intervention records

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -14,6 +14,12 @@ const createRecord = (req, res) => {
   });
 };
 
+const fetchAllRecords = (req, res) =>
+  Intervention.getAll().then(({ rows }) =>
+    rows.length > 0 ? successResponse(res, rows) : successResponse(res)
+  );
+
 export default {
   createRecord,
+  fetchAllRecords,
 };

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -53,4 +53,6 @@ router.post(
   interventionController.createRecord
 );
 
+router.get('/interventions', interventionController.fetchAllRecords);
+
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -1,5 +1,5 @@
 import db from '../src/db/dbrc';
-import { RedFlag } from '../src/models/records';
+import { RedFlag, Intervention } from '../src/models/records';
 import {
   ID,
   recordPatches,
@@ -224,6 +224,21 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(status).eq(201);
             expect(body.data[0].message).eq('Created Intervention record');
             done();
+          });
+      });
+    });
+
+    describe('Fetching', () => {
+      it('Should fetch all available intervention records', async () => {
+        await new Intervention(sampleInterventionToAdd).save();
+        await new Intervention(sampleInterventionToAdd).save();
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/interventions/`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data).to.be.an.instanceof(Array);
+            expect(body.data[0]).to.be.an('object');
           });
       });
     });


### PR DESCRIPTION
**What does this PR do?**

Sets up the "all intervention" record fetching endpoint(`GET`) at `/api/v1/interventions` 

**Description of Task to be completed?**
- Add tests for fetching all intervention records
- Implement record fetching route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-get-all-interventions`
- run `npm run devstart`
 test red-flag record fetching by creating some records then sending `GET` requests `${ROOT_URL}/interventions` 
where `${ROOT_URL}` is the API prefix URL on your local machine

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162531544](https://www.pivotaltracker.com/story/show/162531544)

Screenshots (if appropriate)

N/A

Questions:

N/A