### PR TITLE
#162531540 User can fetch specific intervention record by ID

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -19,7 +19,10 @@ const fetchAllRecords = (req, res) =>
     rows.length > 0 ? successResponse(res, rows) : successResponse(res)
   );
 
+const fetchRecordByID = ({ record }, res) => successResponse(res, record);
+
 export default {
   createRecord,
   fetchAllRecords,
+  fetchRecordByID,
 };

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -55,4 +55,10 @@ router.post(
 
 router.get('/interventions', interventionController.fetchAllRecords);
 
+router.get(
+  '/interventions/:id',
+  loadRecordByID('intervention'),
+  interventionController.fetchRecordByID
+);
+
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -241,6 +241,18 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             expect(body.data[0]).to.be.an('object');
           });
       });
+
+      it('Should fetch a specific intervention record by ID', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/interventions/5`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data).to.be.an.instanceof(Array);
+            expect(body.data[0]).to.be.an('object');
+            done();
+          });
+      });
     });
   });
 };


### PR DESCRIPTION
**What does this PR do?**

Sets up the "specific intervention" record fetching endpoint(`GET`) at `/api/v1/interventions/:id` 

**Description of Task to be completed?**
- Add tests for fetching a specific intervention record by id
- Implement record specific intervention record fetching route

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-get-one-intervention-162531540`
- run `npm run devstart`
- Create some records
 test intervention record fetching by sending get requests `${ROOT_URL}/interventions/:id` 
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the order to fetch

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162531540](https://www.pivotaltracker.com/story/show/162531540)

Screenshots (if appropriate)

N/A

Questions:

N/A