### PR TITLE
Users can update intervention comment/location

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -34,9 +34,23 @@ const updateComment = ({ body, record }, res) =>
         message: 'Comment unchanged, nothing to update',
       });
 
+const updateLocation = ({ body, record }, res) =>
+  record.location !== body.location
+    ? Intervention.patch(record.id, body.location, 'location').then(({ id }) =>
+        successResponse(res, {
+          id,
+          message: 'Updated intervention record’s location',
+        })
+      )
+    : successResponse(res, {
+        id: record.id,
+        message: 'Location unchanged, nothing to update',
+      });
+
 export default {
   createRecord,
   fetchAllRecords,
   fetchRecordByID,
   updateComment,
+  updateLocation,
 };

--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -21,8 +21,22 @@ const fetchAllRecords = (req, res) =>
 
 const fetchRecordByID = ({ record }, res) => successResponse(res, record);
 
+const updateComment = ({ body, record }, res) =>
+  record.comment !== body.comment
+    ? Intervention.patch(record.id, body.comment, 'comment').then(({ id }) =>
+        successResponse(res, {
+          id,
+          message: 'Updated intervention record’s comment',
+        })
+      )
+    : successResponse(res, {
+        id: record.id,
+        message: 'Comment unchanged, nothing to update',
+      });
+
 export default {
   createRecord,
   fetchAllRecords,
   fetchRecordByID,
+  updateComment,
 };

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -69,4 +69,12 @@ router.patch(
   interventionController.updateComment
 );
 
+router.patch(
+  '/interventions/:id/location',
+  checkRequired('location'),
+  loadRecordByID('intervention'),
+  verifyRequestTypes,
+  interventionController.updateLocation
+);
+
 export default router;

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -61,4 +61,12 @@ router.get(
   interventionController.fetchRecordByID
 );
 
+router.patch(
+  '/interventions/:id/comment',
+  checkRequired('comment'),
+  loadRecordByID('intervention'),
+  verifyRequestTypes,
+  interventionController.updateComment
+);
+
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -281,6 +281,32 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             done();
           });
       });
+
+      it('Should succesfully update location of record with valid id', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/interventions/5/location`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+            done();
+          });
+      });
+
+      it('Should return success when location patch equals original', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/interventions/5/location`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+            done();
+          });
+      });
     });
   });
 };

--- a/test/records.js
+++ b/test/records.js
@@ -254,5 +254,33 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           });
       });
     });
+
+    describe('Updating', () => {
+      it('Should succesfully update comment of record with valid id', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/interventions/5/comment`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+            done();
+          });
+      });
+
+      it('Should return success when comment patch equals original', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/interventions/5/comment`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+            done();
+          });
+      });
+    });
   });
 };


### PR DESCRIPTION
**What does this PR do?**

Sets up the  intervention record comment and location updating endpoints(`PATCH`) at `/api/v1/interventions/:id/location` and `/api/v1/rinterventions/:id/comment` respectively

**Description of Task to be completed?**
- Add tests for updating a specific red-flag record location and comment
- Implement saved red-flag record comment/location data updates

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-update-interventions`
- run `npm run devstart`
- Create some intervention records
 test red-flag record updating by sending `PATCH` requests `${ROOT_URL}/interventions/:id/comment` and `${ROOT_URL}/interventions/:id/location`
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the record to update

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162454665](https://www.pivotaltracker.com/story/show/162454665)
[162454725](https://www.pivotaltracker.com/story/show/162454725)

Screenshots (if appropriate)

N/A

Questions:

N/A