### PR TITLE
#162482296 User can delete intervention record

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -47,10 +47,19 @@ const updateLocation = ({ body, record }, res) =>
         message: 'Location unchanged, nothing to update',
       });
 
+const deleteRecordByID = ({ record }, res) =>
+  Intervention.delete(record.id).then(() =>
+    successResponse(res, {
+      id: record.id,
+      message: 'intervention record has been deleted',
+    })
+  );
+
 export default {
   createRecord,
   fetchAllRecords,
   fetchRecordByID,
   updateComment,
   updateLocation,
+  deleteRecordByID,
 };

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -77,4 +77,10 @@ router.patch(
   interventionController.updateLocation
 );
 
+router.delete(
+  '/interventions/:id',
+  loadRecordByID('intervention'),
+  redFlagController.deleteRecordByID
+);
+
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -308,5 +308,19 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           });
       });
     });
+
+    describe('Deletion', () => {
+      it('Should delete a record found by id', done => {
+        chai
+          .request(server)
+          .delete(`${ROOT_URL}/interventions/5`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data).is.an.instanceof(Array);
+            expect(body.data[0]).to.have.property('message');
+            done();
+          });
+      });
+    });
   });
 };


### PR DESCRIPTION
**What does this PR do?**

Sets up the  red-flag record deletion endpoint(`DELETE`) at `/api/v1/interventions/:id/` 

**Description of Task to be completed?**
- Add tests for deleting a specific intervention record 
- Implement intervention record deletion functionality

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-update-red-flag`
- run `npm run devstart`
- Create some records
 test interventions record deletion by creating some records then sending `DELETE` requests `${ROOT_URL}/interventions/:id/`
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the record to drop

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162482296](https://www.pivotaltracker.com/story/show/162482296)

Screenshots (if appropriate)

N/A

Questions:

N/A