### PR TITLE
#162571428 Admin user can mutate record status

### DIFF
--- a/src/config/envConf.js
+++ b/src/config/envConf.js
@@ -2,10 +2,28 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 const { env } = process;
+const {
+  ADMIN_EMAIL,
+  ADMIN_USERNAME,
+  ADMIN_PASSWORD,
+  ADMIN_FIRST_NAME,
+  ADMIN_LAST_NAME,
+  NODE_ENV,
+  PORT,
+  DATABASE_URL,
+  JWT_SECRET,
+} = env;
 
 export default {
-  NODE_ENV: env.NODE_ENV,
-  PORT: env.PORT,
-  DATABASE_URL: env.DATABASE_URL,
-  JWT_SECRET: env.JWT_SECRET,
+  ADMIN: {
+    email: ADMIN_EMAIL,
+    username: ADMIN_USERNAME,
+    password: ADMIN_PASSWORD,
+    firstname: ADMIN_FIRST_NAME,
+    lastname: ADMIN_LAST_NAME,
+  },
+  DATABASE_URL,
+  JWT_SECRET,
+  NODE_ENV,
+  PORT,
 };

--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -47,6 +47,17 @@ const updateLocation = ({ body, record }, res) =>
         message: 'Location unchanged, nothing to update',
       });
 
+const updateStatus = ({ body, record }, res) =>
+  record.status !== body.status
+    ? Intervention.patch(record.id, body.status, 'status').then(({ id }) =>
+        successResponse(res, {
+          id,
+          message: 'Updated intervention record’s status',
+          record: { ...record, ...{ status: body.status } },
+        })
+      )
+    : successResponse(res, {}, 304);
+
 const deleteRecordByID = ({ record }, res) =>
   Intervention.delete(record.id).then(() =>
     successResponse(res, {
@@ -61,5 +72,6 @@ export default {
   fetchRecordByID,
   updateComment,
   updateLocation,
+  updateStatus,
   deleteRecordByID,
 };

--- a/src/controllers/redFlagController.js
+++ b/src/controllers/redFlagController.js
@@ -47,6 +47,17 @@ const updateLocation = ({ body, record }, res) =>
         message: 'Location unchanged, nothing to update',
       });
 
+const updateStatus = ({ body, record }, res) =>
+  record.status !== body.status
+    ? RedFlag.patch(record.id, body.status, 'status').then(({ id }) =>
+        successResponse(res, {
+          id,
+          message: 'Updated red-flag record’s status',
+          record: { ...record, ...{ status: body.status } },
+        })
+      )
+    : successResponse(res, {}, 304);
+
 const deleteRecordByID = ({ record }, res) =>
   RedFlag.delete(record.id).then(() =>
     successResponse(res, {
@@ -61,5 +72,6 @@ export default {
   fetchRecordByID,
   updateComment,
   updateLocation,
+  updateStatus,
   deleteRecordByID,
 };

--- a/src/middlewares/onlyAdmin.js
+++ b/src/middlewares/onlyAdmin.js
@@ -1,0 +1,10 @@
+import handleError from '../helpers/errorHelper';
+
+export default ({ user }, res, next) =>
+  user && user.is_admin
+    ? next()
+    : handleError(
+        res,
+        'you do not have sufficient privileges to access the requested resouce',
+        401
+      );

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -10,16 +10,15 @@ export const validTypes = {
   password: String(),
 };
 
-export const checkRequired = checkWhat => (req, res, next) => {
+export const checkRequired = paramToCheck => (req, res, next) => {
   const { body } = req;
   const missingFields = [];
 
-  switch (checkWhat) {
+  switch (paramToCheck) {
     case 'comment':
-      if (!body.comment) missingFields.push('comment');
-      break;
     case 'location':
-      if (!body.location) missingFields.push('location');
+    case 'status':
+      if (!body[paramToCheck]) missingFields.push(paramToCheck);
       break;
     case 'record':
       missingFields.push(

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -1,4 +1,8 @@
 import db from '../db/db';
+import env from '../config/envConf';
+import { hashPass } from '../helpers/password_helpers';
+
+const { ADMIN } = env;
 
 export class User {
   constructor({
@@ -54,11 +58,22 @@ export class Admin extends User {
   constructor({ ...args }) {
     super(args);
     this.isAdmin = true;
+    this.password = hashPass(this.password);
+  }
+
+  static init() {
+    super.findByUsername(ADMIN.username).then(({ rows }) =>
+      !rows[0]
+        ? (async () => {
+            await new Admin(ADMIN).save();
+          })()
+        : null
+    );
   }
 
   save() {
     const queryString = [
-      `INSERT INTO records(firstname,
+      `INSERT INTO users(firstname,
         lastname,
         othernames,
         username,
@@ -81,3 +96,5 @@ export class Admin extends User {
     return db.query(...queryString);
   }
 }
+
+Admin.init();

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -8,6 +8,7 @@ import {
 } from '../middlewares/sanitizeRequest';
 import loadRecordByID from '../middlewares/loadRecordByID';
 import validUser from '../middlewares/validUser';
+import onlyAdmin from '../middlewares/onlyAdmin';
 
 const router = new Router();
 
@@ -19,13 +20,16 @@ router.post(
   verifyRequestTypes,
   redFlagController.createRecord
 );
+
 router.get('/red-flags', validUser, redFlagController.fetchAllRecords);
+
 router.get(
   '/red-flags/:id',
   validUser,
   loadRecordByID('red-flag'),
   redFlagController.fetchRecordByID
 );
+
 router.patch(
   '/red-flags/:id/comment',
   validUser,
@@ -34,6 +38,17 @@ router.patch(
   loadRecordByID('red-flag'),
   redFlagController.updateComment
 );
+
+router.patch(
+  '/red-flags/:id/status',
+  validUser,
+  onlyAdmin,
+  checkRequired('status'),
+  verifyRequestTypes,
+  loadRecordByID('red-flag'),
+  redFlagController.updateStatus
+);
+
 router.patch(
   '/red-flags/:id/location',
   validUser,
@@ -42,6 +57,7 @@ router.patch(
   loadRecordByID('red-flag'),
   redFlagController.updateLocation
 );
+
 router.delete(
   '/red-flags/:id',
   validUser,
@@ -85,6 +101,16 @@ router.patch(
   verifyRequestTypes,
   loadRecordByID('intervention'),
   interventionController.updateLocation
+);
+
+router.patch(
+  '/interventions/:id/status',
+  validUser,
+  onlyAdmin,
+  checkRequired('status'),
+  verifyRequestTypes,
+  loadRecordByID('intervention'),
+  interventionController.updateStatus
 );
 
 router.delete(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,6 +3,8 @@ import tokenGen from '../src/helpers/tokenGen';
 export const recordPatches = {
   comment: 'lorem ipsum dolor sit amet',
   location: '-94.68589980000002, 46.729553',
+  status: 'resolved',
+  invalidStatus: 'gibberish',
 };
 
 export const records = {

--- a/test/records.js
+++ b/test/records.js
@@ -416,5 +416,31 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           done();
         });
     });
+
+    it('Updated record should be sent along with response body on successful update', done => {
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/interventions/4/status`)
+        .set('authorization', `Bearer ${adminToken}`)
+        .send(recordPatches)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body).to.have.property('data');
+          expect(body.data[0].record.status).eq(recordPatches.status);
+          done();
+        });
+    });
+
+    it('Should not modify record when status to set is already set', done => {
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/interventions/4/status`)
+        .set('authorization', `Bearer ${adminToken}`)
+        .send(recordPatches)
+        .end((err, { status }) => {
+          expect(status).eq(304);
+          done();
+        });
+    });
   });
 };

--- a/test/records.js
+++ b/test/records.js
@@ -1,5 +1,6 @@
 import { RedFlag, Intervention } from '../src/models/records';
 import { recordPatches, records, user } from './helpers';
+import env from '../src/config/envConf';
 
 export default ({ server, chai, expect, ROOT_URL }) => {
   let authToken;
@@ -354,6 +355,66 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             done();
           });
       });
+    });
+  });
+
+  describe('Order Status mutations', () => {
+    let adminToken;
+    before(done => {
+      chai
+        .request(server)
+        .post(`${ROOT_URL}/auth/login`)
+        .send(env.ADMIN)
+        .end((err, { body }) => {
+          [{ token: adminToken }] = body.data;
+          done();
+        });
+    });
+
+    it('Non-admin should not mutate record status', done => {
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/interventions/4/status`)
+        .set('authorization', `Bearer ${authToken}`)
+        .send(recordPatches)
+        .end((err, { body, status }) => {
+          expect(status).eq(401);
+          expect(body).to.have.property('errors');
+          expect(body.errors[0]).eq(
+            'you do not have sufficient privileges to access the requested resouce'
+          );
+          done();
+        });
+    });
+
+    it('Admin should not set an invalid status', done => {
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/red-flags/2/status`)
+        .set('authorization', `Bearer ${adminToken}`)
+        .send({ status: recordPatches.invalidStatus })
+        .end((err, { body, status }) => {
+          expect(status).eq(422);
+          expect(body).to.have.property('errors');
+          expect(body.errors[0]).eq(
+            `cannot parse invalid status "${recordPatches.invalidStatus}".`
+          );
+          done();
+        });
+    });
+
+    it('Admin can mutate record status', done => {
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/red-flags/2/status`)
+        .set('authorization', `Bearer ${adminToken}`)
+        .send(recordPatches)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body).to.have.property('data');
+          expect(body.data[0]).to.have.property('message');
+          done();
+        });
     });
   });
 };


### PR DESCRIPTION
**What does this PR do?**

Grants admin users the privilege to modify the status of an incident(record) on iReporter.
The valid status states are `draft`, `under investigation`, `resolved`, `rejected` 

**Description of Task to be completed?**
- Add tests to validate `onlyAdmin` access to orderStatus mutation routes
- Provision default admin user
- Implement  onlyAdmin middleware
- Implement record status mutations.

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-admin-status-mutations-162571428`
- run `npm run devstart`

 Test record status mutations by creating user/admin accounts, create some records, then send record status mutation `POST` requests `${ROOT_URL}/<record type>/:id/`
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the record to update

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162571428](https://www.pivotaltracker.com/story/show/162571428)

Screenshots (if appropriate)

N/A

Questions:

N/A