### PR TITLE
#162623652 User can modify only saved draft records

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -1,5 +1,6 @@
 import { Intervention } from '../models/records';
 import successResponse from '../helpers/successResponse';
+import handleError from '../helpers/errorHelper';
 
 const createRecord = (req, res) => {
   const { title, comment, location } = req.body;
@@ -21,31 +22,49 @@ const fetchAllRecords = (req, res) =>
 
 const fetchRecordByID = ({ record }, res) => successResponse(res, record);
 
-const updateComment = ({ body, record }, res) =>
-  record.comment !== body.comment
-    ? Intervention.patch(record.id, body.comment, 'comment').then(({ id }) =>
-        successResponse(res, {
-          id,
-          message: 'Updated intervention record’s comment',
-        })
-      )
-    : successResponse(res, {
-        id: record.id,
-        message: 'Comment unchanged, nothing to update',
-      });
+const updateComment = ({ body, editable, record }, res) => {
+  if (editable && record.comment !== body.comment) {
+    Intervention.patch(record.id, body.comment, 'comment').then(({ id }) =>
+      successResponse(res, {
+        id,
+        message: 'Updated intervention record’s comment',
+        record: { ...record, ...{ comment: body.comment } },
+      })
+    );
+  } else if (!editable) {
+    handleError(
+      res,
+      `Cannot change comment of intervention record marked as "${
+        record.status
+      }"`,
+      403
+    );
+  } else {
+    successResponse(res, {}, 304);
+  }
+};
 
-const updateLocation = ({ body, record }, res) =>
-  record.location !== body.location
-    ? Intervention.patch(record.id, body.location, 'location').then(({ id }) =>
-        successResponse(res, {
-          id,
-          message: 'Updated intervention record’s location',
-        })
-      )
-    : successResponse(res, {
-        id: record.id,
-        message: 'Location unchanged, nothing to update',
-      });
+const updateLocation = ({ body, editable, record }, res) => {
+  if (editable && record.location !== body.location) {
+    Intervention.patch(record.id, body.location, 'location').then(({ id }) =>
+      successResponse(res, {
+        id,
+        message: 'Updated intervention record’s location',
+        record: { ...record, ...{ location: body.location } },
+      })
+    );
+  } else if (!editable) {
+    handleError(
+      res,
+      `Cannot change location of intervention record marked as "${
+        record.status
+      }"`,
+      403
+    );
+  } else {
+    successResponse(res, {}, 304);
+  }
+};
 
 const updateStatus = ({ body, record }, res) =>
   record.status !== body.status

--- a/src/middlewares/loadRecordByID.js
+++ b/src/middlewares/loadRecordByID.js
@@ -8,9 +8,16 @@ export default type => (req, res, next) => {
   Record.getOneByID(jsonParse(id)).then(({ rows }) =>
     rows[0] && rows[0].type === type
       ? (() => {
+          if (
+            !['under investigation', 'resolved', 'rejeted'].includes(
+              rows[0].status
+            )
+          ) {
+            req.editable = true;
+          }
           req.record = { ...rows[0] };
           next();
         })()
-      : handleError(res, `No record exists with id '${id}'`, 404)
+      : handleError(res, `No ${type} record exists with id '${id}'`, 404)
   );
 };

--- a/test/records.js
+++ b/test/records.js
@@ -48,7 +48,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .set('authorization', `Bearer ${authToken}`)
           .end((err, { body, status }) => {
             expect(status).eq(404);
-            expect(body.errors[0]).eq(`No record exists with id '10'`);
+            expect(body.errors[0]).eq(`No red-flag record exists with id '10'`);
             done();
           });
       });
@@ -179,10 +179,8 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .patch(`${ROOT_URL}/red-flags/1/location`)
           .set('authorization', `Bearer ${authToken}`)
           .send(recordPatches)
-          .end((err, { body, status }) => {
-            expect(status).eq(200);
-            expect(body).to.have.property('data');
-            expect(body.data[0]).to.have.property('message');
+          .end((err, { status }) => {
+            expect(status).eq(304);
           });
       });
 
@@ -205,10 +203,8 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .patch(`${ROOT_URL}/red-flags/1/comment`)
           .set('authorization', `Bearer ${authToken}`)
           .send(recordPatches)
-          .end((err, { body, status }) => {
-            expect(status).eq(200);
-            expect(body).to.have.property('data');
-            expect(body.data[0]).to.have.property('message');
+          .end((err, { status }) => {
+            expect(status).eq(304);
           });
       });
     });
@@ -305,10 +301,8 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .patch(`${ROOT_URL}/interventions/3/comment`)
           .set('authorization', `Bearer ${authToken}`)
           .send(recordPatches)
-          .end((err, { body, status }) => {
-            expect(status).eq(200);
-            expect(body).to.have.property('data');
-            expect(body.data[0]).to.have.property('message');
+          .end((err, { status }) => {
+            expect(status).eq(304);
             done();
           });
       });
@@ -333,10 +327,8 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .patch(`${ROOT_URL}/interventions/3/location`)
           .set('authorization', `Bearer ${authToken}`)
           .send(recordPatches)
-          .end((err, { body, status }) => {
-            expect(status).eq(200);
-            expect(body).to.have.property('data');
-            expect(body.data[0]).to.have.property('message');
+          .end((err, { status }) => {
+            expect(status).eq(304);
             done();
           });
       });
@@ -439,6 +431,49 @@ export default ({ server, chai, expect, ROOT_URL }) => {
         .send(recordPatches)
         .end((err, { status }) => {
           expect(status).eq(304);
+          done();
+        });
+    });
+
+    it('Should not modify record location/comment when record status has been mutated', done => {
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/red-flags/2/location`)
+        .set('authorization', `Bearer ${authToken}`)
+        .send(records.sampleValidRedFlag)
+        .end((err, { body, status }) => {
+          expect(status).eq(403);
+          expect(body.errors).is.an.instanceof(Array);
+        });
+
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/red-flags/2/comment`)
+        .set('authorization', `Bearer ${authToken}`)
+        .send(records.sampleValidRedFlag)
+        .end((err, { body, status }) => {
+          expect(status).eq(403);
+          expect(body.errors).is.an.instanceof(Array);
+        });
+
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/interventions/4/location`)
+        .set('authorization', `Bearer ${authToken}`)
+        .send(records.sampleIntervention)
+        .end((err, { body, status }) => {
+          expect(status).eq(403);
+          expect(body.errors).is.an.instanceof(Array);
+        });
+
+      chai
+        .request(server)
+        .patch(`${ROOT_URL}/interventions/4/comment`)
+        .set('authorization', `Bearer ${authToken}`)
+        .send(records.sampleIntervention)
+        .end((err, { body, status }) => {
+          expect(status).eq(403);
+          expect(body.errors).is.an.instanceof(Array);
           done();
         });
     });


### PR DESCRIPTION
**What does this PR do?**

Imposes constraints on record updates. Users cannot edit records which are `under investigation`, `resolved` or `rejected`. 

**Description of Task to be completed?**
- Add tests to validate record update constraints
- Implement record update constraints.

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-record-update-constraints-162623652`
- run `npm run devstart`

 Test update constraints  by creating user/admin accounts, create change the status of some records, then send record location/comment updating`POST` requests `${ROOT_URL}/<record type>/:id/<comment | location>`
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the record to update

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162623652](https://www.pivotaltracker.com/story/show/162623652)

Screenshots (if appropriate)

N/A

Questions:

N/A