### PR TITLE
#162626696 User can delete only draft records

### DIFF
--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -77,13 +77,19 @@ const updateStatus = ({ body, record }, res) =>
       )
     : successResponse(res, {}, 304);
 
-const deleteRecordByID = ({ record }, res) =>
-  Intervention.delete(record.id).then(() =>
-    successResponse(res, {
-      id: record.id,
-      message: 'intervention record has been deleted',
-    })
-  );
+const deleteRecordByID = ({ editable, record }, res) =>
+  editable
+    ? Intervention.delete(record.id).then(() =>
+        successResponse(res, {
+          id: record.id,
+          message: 'Intervention record has been deleted',
+        })
+      )
+    : handleError(
+        res,
+        `Cannot delete intervention record marked as "${record.status}"`,
+        403
+      );
 
 export default {
   createRecord,

--- a/src/controllers/redFlagController.js
+++ b/src/controllers/redFlagController.js
@@ -73,13 +73,19 @@ const updateStatus = ({ body, record }, res) =>
       )
     : successResponse(res, {}, 304);
 
-const deleteRecordByID = ({ record }, res) =>
-  RedFlag.delete(record.id).then(() =>
-    successResponse(res, {
-      id: record.id,
-      message: 'red-flag record has been deleted',
-    })
-  );
+const deleteRecordByID = ({ editable, record }, res) =>
+  editable
+    ? RedFlag.delete(record.id).then(() =>
+        successResponse(res, {
+          id: record.id,
+          message: 'Red-flag record has been deleted',
+        })
+      )
+    : handleError(
+        res,
+        `Cannot delete red-flag record marked as "${record.status}"`,
+        403
+      );
 
 export default {
   createRecord,

--- a/test/records.js
+++ b/test/records.js
@@ -477,5 +477,26 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           done();
         });
     });
+
+    it('Should not delete record when record status has been mutated', done => {
+      chai
+        .request(server)
+        .delete(`${ROOT_URL}/red-flags/2`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(403);
+          expect(body.errors).is.an.instanceof(Array);
+        });
+
+      chai
+        .request(server)
+        .delete(`${ROOT_URL}/interventions/4`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(403);
+          expect(body.errors).is.an.instanceof(Array);
+          done();
+        });
+    });
   });
 };


### PR DESCRIPTION
**What does this PR do?**

Imposes constraints on record deletions. Users cannot delete records which are `under investigation`, `resolved` or `rejected`. 

**Description of Task to be completed?**
- Add tests to validate record deletion constraints
- Implement record deletion constraints.

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-record-update-constraints-162623652`
- run `npm run devstart`

 Test record deletion constraints  by creating user/admin accounts, create change the status of some records, then send record `DELETE` requests `${ROOT_URL}/<record type>/:id/`
where `${ROOT_URL}` is the API prefix URL on your local machine and `:id` is the id of the record to delete

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162626696](https://www.pivotaltracker.com/story/show/162626696)

Screenshots (if appropriate)

N/A

Questions:

N/A