### PR TITLE
#162627982 Serve API swagger documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "express": "^4.16.4",
     "jsonwebtoken": "^8.4.0",
     "morgan": "^1.9.1",
-    "pg": "^7.7.1"
+    "pg": "^7.7.1",
+    "swagger-ui-express": "^4.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,11 +1,15 @@
 import recordRouter from './records';
 import authRouter from './auth';
+import apiSpec from '../../utils/swagger_spec.json';
+
+const { serve, setup } = require('swagger-ui-express');
 
 const ROOT_URL = '/api/v1';
 
 const router = app => {
   app.use(ROOT_URL, recordRouter);
   app.use(ROOT_URL, authRouter);
+  app.use('/api-docs', serve, setup(apiSpec));
 };
 
 export default router;

--- a/utils/swagger_spec.json
+++ b/utils/swagger_spec.json
@@ -1,0 +1,632 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "iReporter",
+    "description": "iReporter enables any/every citizen to bring any form of corruption to the notice of appropriate authorities and the general public. Users can also report on things that need government intervention",
+    "version": "0.0.1"
+  },
+  "servers": [
+    {
+      "url": "https://ireporter-pms.herokuapp.com"
+    }
+  ],
+  "tags": [
+    {
+      "name": "auth",
+      "description": "Auth endpoints"
+    },
+    {
+      "name": "redFlags",
+      "description": "Access to red-flag record endpoints"
+    },
+    {
+      "name": "interventions",
+      "description": "Access to intervention record endpoints"
+    }
+  ],
+  "paths": {
+    "/api/v1/auth/signup": {
+      "post": {
+        "description": "Create new user account on iReporter",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  },
+                  "firstname": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  },
+                  "lastname": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful account creation"
+          },
+          "400": {
+            "description": "Missing required fields"
+          },
+          "409": {
+            "description": "User exists"
+          },
+          "422": {
+            "description": "invalid request values"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "description": "User login",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful login"
+          },
+          "400": {
+            "description": "incorrect password"
+          },
+          "401": {
+            "description": "unregistered user"
+          }
+        }
+      }
+    },
+    "/api/v1/red-flags": {
+      "get": {
+        "description": "fetch all red-flag records",
+        "tags": [
+          "redFlags"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful fetch"
+          }
+        }
+      },
+      "post": {
+        "description": "Create new red-flag record",
+        "tags": [
+          "redFlags"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful creation"
+          },
+          "400": {
+            "description": "Missing required fields"
+          },
+          "422": {
+            "description": "Invalid field types"
+          }
+        }
+      }
+    },
+    "/api/v1/red-flags/{id}": {
+      "get": {
+        "description": "get red-flag record by id",
+        "tags": [
+          "redFlags"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to get"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful fetch"
+          },
+          "404": {
+            "description": "not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "redFlags"
+        ],
+        "description": "Delete red-flag record",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful deletion"
+          }
+        }
+      }
+    },
+    "/api/v1/red-flags/{id}/comment": {
+      "patch": {
+        "tags": [
+          "redFlags"
+        ],
+        "description": "Update comment on red-flag record",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to update"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "0": {
+                  "value": "{\"comment\": \"new comment\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful update"
+          },
+          "403": {
+            "description": "Record not editable"
+          },
+          "404": {
+            "description": "Record non-existent"
+          }
+        }
+      }
+    },
+    "/api/v1/red-flags/{id}/location": {
+      "patch": {
+        "tags": [
+          "redFlags"
+        ],
+        "description": "Update location on red-flag record",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to update"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "0": {
+                  "value": "{\"location\": \"180,23.2\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Auto generated using Swagger Inspector",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/red-flags/{id}/status": {
+      "patch": {
+        "tags": [
+          "redFlags"
+        ],
+        "description": "Update red-flag record status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to update"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "0": {
+                  "value": "{\"status\": \"resolved\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful update"
+          },
+          "403": {
+            "description": "Insufficient privileges"
+          }
+        }
+      }
+    },
+    "/api/v1/interventions": {
+      "get": {
+        "tags": [
+          "interventions"
+        ],
+        "description": "fetch all intervention records",
+        "responses": {
+          "200": {
+            "description": "Successful fetch"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "interventions"
+        ],
+        "description": "Create new intervention record",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful creation"
+          },
+          "400": {
+            "description": "Missing required fields"
+          },
+          "422": {
+            "description": "Invalid field types"
+          }
+        }
+      }
+    },
+    "/api/v1/interventions/{id}": {
+      "get": {
+        "tags": [
+          "interventions"
+        ],
+        "description": "get intervention record by id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to get"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful fetch"
+          },
+          "404": {
+            "description": "not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "interventions"
+        ],
+        "description": "Delete intervention record",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful deletion"
+          }
+        }
+      }
+    },
+    "/api/v1/interventions/{id}/comment": {
+      "patch": {
+        "tags": [
+          "interventions"
+        ],
+        "description": "Update comment on intervention record",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to update"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "0": {
+                  "value": "{\"comment\": \"new comment\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful update"
+          },
+          "403": {
+            "description": "Record not editable"
+          },
+          "404": {
+            "description": "Record non-existent"
+          }
+        }
+      }
+    },
+    "/api/v1/interventions/{id}/location": {
+      "patch": {
+        "tags": [
+          "interventions"
+        ],
+        "description": "Update location on intervention record",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to update"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "0": {
+                  "value": "{\"location\": \"180,23.2\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Auto generated using Swagger Inspector",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/interventions/{id}/status": {
+      "patch": {
+        "tags": [
+          "interventions"
+        ],
+        "description": "Update intervention record status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "The id of record to update"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "0": {
+                  "value": "{\"status\": \"resolved\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful update"
+          },
+          "403": {
+            "description": "Insufficient privileges"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "tokenAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "security": [
+    {
+      "tokenAuth": []
+    }
+  ]
+}


### PR DESCRIPTION
**What does this PR do?**

Makes swagger documentation of API endpoints available at `/api-docs`

**Description of Task to be completed?**
-  Serve swagger docs

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ch-document-api-162627982`
- Run `npm run devstart`
 Open a browser window and navigate to `${SERVER_URL}/api-docs`
 Where `${SERVER_URL}` is the `host:port` address  the development server is listening on


**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162627982](https://www.pivotaltracker.com/story/show/162627982)

Screenshots (if appropriate)

N/A

Questions:

N/A