### PR TITLE
#162749827 Users can get optional record status email updates 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "initdb": "DEBUG=iReporter* babel-node src/db/dbrc.js init",
     "db-drop": "DEBUG=iReporter* babel-node src/db/dbrc.js drop",
     "heroku-postbuild": " npm run build",
+    "live:initdb": "DEBUG=iReporter* node src/db/dbrc.js init",
+    "live:db-drop": "DEBUG=iReporter* node src/db/dbrc.js drop",
     "start": "node dist/server",
     "test": "DEBUG=iReporter* nyc mocha test/index.js --exit"
   },
@@ -47,6 +49,7 @@
   },
   "homepage": "https://ope-oguntoye.github.io/iReporter",
   "dependencies": {
+    "@sendgrid/mail": "^6.3.1",
     "bcryptjs": "^2.4.3",
     "debug": "^4.1.0",
     "dotenv": "^6.1.0",

--- a/src/config/envConf.js
+++ b/src/config/envConf.js
@@ -12,6 +12,7 @@ const {
   PORT,
   DATABASE_URL,
   JWT_SECRET,
+  SENDGRID_KEY,
 } = env;
 
 export default {
@@ -26,4 +27,5 @@ export default {
   JWT_SECRET,
   NODE_ENV,
   PORT,
+  SENDGRID_KEY,
 };

--- a/src/db/dbrc.js
+++ b/src/db/dbrc.js
@@ -15,6 +15,7 @@ const Models = {
        email  VARCHAR NOT NULL,
        phone  VARCHAR,
        registered TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+       email_notify BOOLEAN DEFAULT 'false',
        is_admin BOOLEAN DEFAULT 'false'
       )`,
 
@@ -29,6 +30,7 @@ const Models = {
        comment VARCHAR NOT NULL,
        location VARCHAR,
        status VARCHAR NOT NULL,
+       email_notify BOOLEAN DEFAULT 'false',
        FOREIGN KEY (created_by) REFERENCES users (id) ON DELETE CASCADE
       )`,
 };

--- a/src/helpers/mailHelper.js
+++ b/src/helpers/mailHelper.js
@@ -1,0 +1,49 @@
+import mailer from '@sendgrid/mail';
+import debug from 'debug';
+import env from '../config/envConf';
+import { User } from '../models/users';
+
+const logger = debug('iReporter::mailer');
+
+mailer.setApiKey(env.SENDGRID_KEY);
+
+const statusNotify = ({
+  id,
+  created_by: userID,
+  email_notify: notify,
+  status,
+  type,
+}) =>
+  notify
+    ? User.findByID(userID).then(({ rowCount, rows }) => {
+        let success;
+        if (rowCount > 0) {
+          const [{ firstname: name, email: userEmail }] = rows;
+
+          const statusUpdateMail = {
+            to: userEmail,
+            from: 'noreply@ireporter.info',
+            subject: 'iReporter record status update',
+            text: `Hi ${name}, the status of your ${type} record(#${id}) was just changed to ${status}.`,
+            html: `Hi <strong>${name}</strong>, 
+              <p>The status of your ${type} record <strong>#${id}</strong> was just changed to ${status}.`,
+          };
+
+          mailer.send(statusUpdateMail).catch(e => {
+            logger(e.toString());
+            success = false;
+          });
+        } else {
+          logger(`Can't find record creator`);
+          success = false;
+        }
+        return success;
+      })
+    : Promise.resolve(
+        (() => {
+          logger(`skipping email notification for ${type} #${id}`);
+          return false;
+        })()
+      );
+
+export default { statusNotify };

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -8,6 +8,7 @@ export const validTypes = {
   status: ['under investigation', 'resolved', 'rejected', 'draft'],
   location: String(),
   password: String(),
+  emailNotify: Boolean(),
 };
 
 export const checkRequired = paramToCheck => (req, res, next) => {
@@ -86,6 +87,14 @@ export const verifyRequestTypes = (req, res, next) => {
         case 'email':
           if (isEmpty(body[param]) || !/^.+@.+\..+$/.test(body[param])) {
             errors.push(`cannot parse invalid email "${body[param]}".`);
+          }
+          break;
+        case 'emailNotify':
+          if (
+            isEmpty(body[param]) ||
+            typeof jsonParse(body[param]) !== typeof validTypes[param]
+          ) {
+            errors.push(`emailNotify must be a boolean`);
           }
           break;
         case 'status':

--- a/src/models/records.js
+++ b/src/models/records.js
@@ -1,7 +1,16 @@
 import db from '../db/db';
 
 export class Record {
-  constructor({ title, type, createdBy, comment, location, images, videos }) {
+  constructor({
+    title,
+    type,
+    createdBy,
+    comment,
+    location,
+    images,
+    videos,
+    emailNotify,
+  }) {
     this.title = title;
     this.type = type;
     this.createdBy = createdBy;
@@ -9,6 +18,7 @@ export class Record {
     this.location = location;
     this.images = images;
     this.videos = videos;
+    this.emailNotify = emailNotify || false;
     this.status = 'draft';
   }
 
@@ -45,7 +55,7 @@ export class Record {
 
   save() {
     const queryString = [
-      'INSERT INTO records(title, type, location, comment, status, created_by) VALUES($1, $2, $3, $4, $5, $6) RETURNING *',
+      'INSERT INTO records(title, type, location, comment, status, created_by, email_notify) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING *',
       [
         this.title,
         this.type,
@@ -53,6 +63,7 @@ export class Record {
         this.comment,
         this.status,
         this.createdBy,
+        this.emailNotify,
       ],
     ];
     return db.query(...queryString);

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -13,6 +13,7 @@ export class User {
     password,
     email,
     phone,
+    emailNotify,
   }) {
     this.firstname = firstname;
     this.lastname = lastname;
@@ -21,7 +22,13 @@ export class User {
     this.password = hashPass(password);
     this.email = email;
     this.phone = phone;
+    this.emailNotify = emailNotify || false;
     this.isAdmin = false;
+  }
+
+  static findByID(id) {
+    const queryString = [`SELECT * FROM users WHERE id = $1`, [id]];
+    return db.query(...queryString);
   }
 
   static findByUsername(username) {
@@ -37,8 +44,10 @@ export class User {
           username,
           password,
           email,
-          phone)
-         VALUES($1, $2, $3, $4, $5, $6, $7)
+          phone,
+          email_notify
+          )
+         VALUES($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING *`,
       [
         this.firstname,
@@ -48,6 +57,7 @@ export class User {
         this.password,
         this.email,
         this.phone,
+        this.emailNotify,
       ],
     ];
     return db.query(...queryString);

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ import server from '../src/server';
 import records from './records';
 import users from './users';
 import tokenAuth from './tokenAuth';
+import mailer from './mailer';
 
 chai.use(chaiHttp);
 
@@ -16,3 +17,4 @@ const testArgs = { server, chai, expect, ROOT_URL, logger };
 tokenAuth(testArgs);
 records(testArgs);
 users(testArgs);
+mailer(testArgs);

--- a/test/mailer.js
+++ b/test/mailer.js
@@ -1,0 +1,33 @@
+import mailHelper from '../src/helpers/mailHelper';
+
+export default ({ expect }) => {
+  describe('Mailer tests', () => {
+    it('Should not send an email to invalid user', () => {
+      mailHelper
+        .statusNotify({
+          id: 1,
+          created_by: 50,
+          email_notify: true,
+          status: 'resolved',
+          type: `intervention`,
+        })
+        .then(success => {
+          expect(success).eq(false);
+        });
+    });
+
+    it('Should not send an email for record with notification turned off', () => {
+      mailHelper
+        .statusNotify({
+          id: 1,
+          created_by: 1,
+          email_notify: false,
+          status: 'resolved',
+          type: `intervention`,
+        })
+        .then(success => {
+          expect(success).eq(false);
+        });
+    });
+  });
+};

--- a/test/records.js
+++ b/test/records.js
@@ -79,18 +79,15 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .request(server)
           .post(`${ROOT_URL}/red-flags`)
           .set('authorization', `Bearer ${authToken}`)
-          .send({ ...records.sampleValidRedFlag, ...{ location: 'knowhere' } })
-          .end((err, { body, status }) => {
-            expect(status).eq(422);
-            expect(body.errors[0]).to.be.a('string');
-          });
-        chai
-          .request(server)
-          .post(`${ROOT_URL}/red-flags`)
-          .set('authorization', `Bearer ${authToken}`)
           .send({
             ...records.sampleValidRedFlag,
-            ...{ email: 'rover.io@', location: '', title: '', comment: {} },
+            ...{
+              email: 'rover.io@',
+              location: '',
+              title: '',
+              comment: {},
+              emailNotify: 'nonBool',
+            },
           })
           .end((err, { body, status }) => {
             expect(status).eq(422);


### PR DESCRIPTION
**What does this PR do?**

Implements functionality to allow users optionally receive email notifications whenever the status of a record they create is changed by an admin

**Description of Task to be completed?**
- Add tests to validate the sanity of `mail helper` 
- Update schema, models and helpers for email notifications
- Implement `mail helper` to provision optional email notifications on record status updates

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-email-notifications-162749827`
- run `npm run devstart`

 Test record status mutations by creating user/admin accounts, create some records, 

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162749827](https://www.pivotaltracker.com/story/show/162749827)

Screenshots (if appropriate)

N/A

Questions:

N/A