### PR TITLE
ch(Admin): Spawn default admin at will

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - psql -U postgres -c 'create database ireporter;'
 script:
 - npm run initdb
+- npm run spawn-admin
 - npm test
 install:
 - npm install

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "build": "babel src -d dist --source-maps",
-    "devstart": "DEBUG=iReporter* nodemon src/server --exec babel-node",
+    "devstart": "npm run initdb && npm run spawn-admin && DEBUG=iReporter* nodemon src/server --exec babel-node",
     "initdb": "DEBUG=iReporter* babel-node src/db/dbrc.js init",
     "db-drop": "DEBUG=iReporter* babel-node src/db/dbrc.js drop",
-    "heroku-postbuild": " npm run build",
+    "spawn-admin": "DEBUG=iReporter* babel-node src/models/users.js spawn-admin",
+    "heroku-postbuild": "npm run build && npm run live:spawn-admin",
     "live:initdb": "DEBUG=iReporter* node src/db/dbrc.js init",
     "live:db-drop": "DEBUG=iReporter* node src/db/dbrc.js drop",
+    "live:spawn-admin": "DEBUG=iReporter* node dist/models/users.js spawn-admin",
     "start": "node dist/server",
     "test": "DEBUG=iReporter* nyc mocha test/index.js --exit"
   },

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -1,7 +1,9 @@
+import debug from 'debug';
 import db from '../db/db';
 import env from '../config/envConf';
 import { hashPass } from '../helpers/password_helpers';
 
+const logger = debug('iReporter::users:');
 const { ADMIN } = env;
 
 export class User {
@@ -70,14 +72,14 @@ export class Admin extends User {
     this.isAdmin = true;
   }
 
+  /* istanbul ignore next */
   static init() {
-    super.findByUsername(ADMIN.username).then(({ rows }) =>
-      !rows[0]
-        ? (async () => {
-            await new Admin(ADMIN).save();
-          })()
-        : null
-    );
+    super.findByUsername(ADMIN.username).then(async ({ rowCount }) => {
+      if (rowCount < 1) {
+        await new Admin(ADMIN).save();
+        logger(`Admin Spawned`);
+      }
+    });
   }
 
   save() {
@@ -106,4 +108,6 @@ export class Admin extends User {
   }
 }
 
-Admin.init();
+process.argv.forEach(arg => {
+  if (arg === 'spawn-admin') Admin.init();
+});


### PR DESCRIPTION
**What does this PR do?**

Implements functionality to create default admin at any time.

**Description of Task to be completed?**
- Make `Admin.init` runnable from package.json
- Update scripts to incorporate runnable `Admin.init` method

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ch-spawn-admin-at-will -162759435`
run `npm run spawn-admin` to test default admin account generation

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[162759435](https://www.pivotaltracker.com/story/show/162759435)

Screenshots (if appropriate)

N/A

Questions:

N/A