### PR TITLE
 #163114848 Users can view all record stats

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
   },
   "rules": {
     "import/prefer-default-export": 0,
+    "no-param-reassign":["error", { "props": false }],
     "prettier/prettier": [
       "error",
       {

--- a/src/controllers/recordController.js
+++ b/src/controllers/recordController.js
@@ -1,0 +1,27 @@
+import { Record } from '../models/records';
+import successResponse from '../helpers/successResponse';
+import handleError from '../helpers/errorHelper';
+
+export default {
+  fetchStats(req, res) {
+    Record.getAll().then(({ rowCount, rows: records }) =>
+      rowCount > 0
+        ? successResponse(
+            res,
+            records.reduce(
+              (statCountObj, { status }) =>
+                statCountObj[status]
+                  ? Object.assign(statCountObj, {
+                      [status]: statCountObj[status] + 1,
+                    })
+                  : Object.assign(statCountObj, {
+                      [status]: 1,
+                    }),
+              {}
+            ),
+            200
+          )
+        : handleError(res, 'No records found', 404)
+    );
+  },
+};

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import interventionController from '../controllers/interventionController';
 import redFlagController from '../controllers/redFlagController';
+import recordController from '../controllers/recordController';
 import {
   checkRequired,
   strictRecordType,
@@ -11,6 +12,8 @@ import validUser from '../middlewares/validUser';
 import onlyAdmin from '../middlewares/onlyAdmin';
 
 const router = new Router();
+
+router.get('/records/stats', validUser, recordController.fetchStats);
 
 router.post(
   '/red-flags',

--- a/test/records.js
+++ b/test/records.js
@@ -617,4 +617,20 @@ export default ({ server, chai, expect, ROOT_URL }) => {
         });
     });
   });
+
+  describe('Record Stats', () => {
+    it('User can get all record stats', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records/stats`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body.data).to.be.an.instanceof(Array);
+          expect(body.data[0]).to.be.an('object');
+          console.log(body.data);
+          done();
+        });
+    });
+  });
 };


### PR DESCRIPTION
**What does this PR do?**
Enables users to fetch and view statistics about the frequency of records across the various status categories.

**Description of Task to be completed?**
- Add tests to validate fetching record stats
- Implement record stats fetching.

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-fetch-all-record-stats-163114848`
- run `npm run devstart`

 Test record statistics fetching by creating some records, then send `GET` requests `${ROOT_URL}/records/stats/`
where `${ROOT_URL}` is the API prefix URL on your local machine.

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163114848](https://www.pivotaltracker.com/story/show/163114848)

Screenshots (if appropriate)

N/A

Questions:

N/A