### PR TITLE
#163130300 Users can view own record stats

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,0 +1,38 @@
+import { Record } from '../models/records';
+import successResponse from '../helpers/successResponse';
+import handleError from '../helpers/errorHelper';
+
+export default {
+  fetchStats(
+    {
+      user: { id: userID },
+    },
+    res
+  ) {
+    return Record.getAll().then(({ rowCount, rows: records }) => {
+      if (rowCount > 0) {
+        const userRecords = records.filter(
+          ({ created_by: creator }) => creator === userID
+        );
+
+        if (userRecords.length > 0) {
+          successResponse(
+            res,
+            userRecords.reduce(
+              (statCountObj, { status }) =>
+                statCountObj[status]
+                  ? Object.assign(statCountObj, {
+                      [status]: statCountObj[status] + 1,
+                    })
+                  : Object.assign(statCountObj, {
+                      [status]: 1,
+                    }),
+              {}
+            ),
+            200
+          );
+        } else handleError(res, 'No records found for user', 404);
+      } else handleError(res, 'No records found', 404);
+    });
+  },
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,6 @@
 import recordRouter from './records';
 import authRouter from './auth';
+import userRouter from './user';
 import apiSpec from '../../utils/swagger_spec.json';
 
 const { serve, setup } = require('swagger-ui-express');
@@ -9,6 +10,7 @@ const ROOT_URL = '/api/v1';
 const router = app => {
   app.use(ROOT_URL, recordRouter);
   app.use(ROOT_URL, authRouter);
+  app.use(ROOT_URL, userRouter);
   app.use('/api-docs', serve, setup(apiSpec));
 };
 

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import userController from '../controllers/userController';
+import validUser from '../middlewares/validUser';
+
+const router = new Router();
+
+router.get('/user/recordstats', validUser, userController.fetchStats);
+
+export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -24,6 +24,29 @@ export default ({ server, chai, expect, ROOT_URL }) => {
     });
 
     describe('Fetching before creation', () => {
+      it('Returns error response when getting record stats', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/stats`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.an('string');
+          });
+
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/recordstats`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.an('string');
+            done();
+          });
+      });
+
       it('Returns an empty array when no records exist', done => {
         chai
           .request(server)
@@ -628,7 +651,32 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           expect(status).eq(200);
           expect(body.data).to.be.an.instanceof(Array);
           expect(body.data[0]).to.be.an('object');
-          console.log(body.data);
+          done();
+        });
+    });
+
+    it('User can get own record stats', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/user/recordstats`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body.data).to.be.an.instanceof(Array);
+          expect(body.data[0]).to.be.an('object');
+          done();
+        });
+    });
+
+    it('Return error if user has no records created', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/user/recordstats`)
+        .set('authorization', `Bearer ${adminToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(404);
+          expect(body.errors).to.be.an.instanceof(Array);
+          expect(body.errors[0]).to.be.a('string');
           done();
         });
     });


### PR DESCRIPTION
**What does this PR do?**
Enables users to fetch and view statistics about the frequency of records across the various status categories.

**Description of Task to be completed?**
- Add tests to validate fetching record stats
- Implement record stats fetching.

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-fetch-own-record-stats-163130300`
- run `npm run devstart`

 Test record statistics fetching by creating some records, then send `GET` requests `${ROOT_URL}/user/recordstats/`
where `${ROOT_URL}` is the API prefix URL on your local machine.

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163130300](https://www.pivotaltracker.com/story/show/163130300)

Screenshots (if appropriate)

N/A

Questions:

N/A