### PR TITLE
#163141848 Implement frontend signup functionality

### DIFF
--- a/UI/assets/css/style.css
+++ b/UI/assets/css/style.css
@@ -368,6 +368,61 @@ a {
   padding-bottom: 1rem;
 }
 
+.auth__messages {
+ font-size: 1.4rem;
+ height: 0;
+ opacity: 0;
+ padding: 1rem 5%;
+ border-radius: 0.7rem;
+ transition: opacity 0.3s ease;
+ visibility: hidden;
+ align-self: center;
+ width: 100%;
+ position: relative;
+}
+
+.auth__messages.visible {
+  margin-bottom: 1rem;
+  min-height: 4rem;
+  height: auto;
+  opacity: 0.96;
+  visibility: visible;
+}
+
+.auth__messages--success {
+  background-color: #007e33;
+  color: white;
+}
+
+.auth__messages--error {
+  background-color: #cc0000;
+  color: white;
+}
+
+.auth__messages-dismiss {
+  position: absolute;
+  right: 0.3rem;
+  top: -0.6rem;
+  font-size: 2.8rem;
+  color: #212121;
+  cursor: pointer;
+}
+
+.auth__messages-dismiss:hover {
+  color: #666;
+}
+
+.auth__message-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-weight: 300;
+}
+
+.auth__message:not(:last-of-type) {
+  margin-bottom: .5rem;
+}
+
 .auth__links {
   text-align: center;
   line-height: 170%;

--- a/UI/assets/js/auth.js
+++ b/UI/assets/js/auth.js
@@ -1,11 +1,35 @@
-const loginForm = document.querySelector('.auth__form--login');
+this.addEventListener('load', () => {
+  const signupForm = document.querySelector('.auth__form--signup');
 
-loginForm.addEventListener('submit', e => {
-  e.preventDefault();
-  const { currentTarget: form } = e;
-  const username = form.querySelector('.form-field__login-username');
-  const password = form.querySelector('.form-field__login-password');
+  const {
+    findMissingFields,
+    makeAuthFormMessages,
+    missingFieldsMessage,
+    signUp,
+    responsiveNav,
+  } = window.IR_HELPERS;
 
-  if (username.value === 'admin' && password.value === 'admin')
-    window.location.assign('admin.html');
+  responsiveNav();
+
+  if (signupForm) {
+    signupForm.addEventListener('submit', e => {
+      e.preventDefault();
+
+      const { currentTarget: form } = e;
+      const { value: firstname } = form.querySelector('.form-field__firstname');
+      const { value: lastname } = form.querySelector('.form-field__lastname');
+      const { value: username } = form.querySelector('.form-field__username');
+      const { value: email } = form.querySelector('.form-field__email');
+      const { value: password } = form.querySelector('.form-field__password');
+
+      const missingFields = findMissingFields({ username, email, password });
+
+      return missingFields.length > 0
+        ? makeAuthFormMessages({
+            type: 'error',
+            messages: [missingFieldsMessage(missingFields)],
+          })
+        : signUp(firstname, lastname, username, email, password);
+    });
+  }
 });

--- a/UI/assets/js/helpers.js
+++ b/UI/assets/js/helpers.js
@@ -1,0 +1,125 @@
+const IR_HELPERS = {
+  API_SIGNUP_URL: 'https://ireporter-pms.herokuapp.com/api/v1/auth/signup',
+
+  redirects: {
+    adminAuthSuccessRedirect: () => window.location.assign('admin.html'),
+    authSuccessRedirect: () => window.location.assign('user.html'),
+  },
+
+  findMissingFields(fields) {
+    const missingFields = [];
+    Object.keys(fields).forEach(fieldName => {
+      if (
+        IR_HELPERS.isEmpty(fields[fieldName]) ||
+        IR_HELPERS.nonExistent(fields[fieldName])
+      )
+        missingFields.push(fieldName);
+    });
+
+    return missingFields;
+  },
+
+  isEmpty(...args) {
+    return args.every(param => param === '');
+  },
+
+  makeAuthFormMessages({ type, messages }) {
+    const alertDiv = document.querySelector('.auth__messages');
+    const dismissButton = document.querySelector('.auth__messages-dismiss');
+    const messageList = document.querySelector('.auth__message-list');
+
+    messages.forEach(message => {
+      messageList.innerHTML += `<li class="auth__message">${message}</li>\n`;
+    });
+
+    alertDiv.classList.add(
+      `${
+        type === 'success' ? 'auth__messages--success' : 'auth__messages--error'
+      }`,
+      'visible'
+    );
+
+    dismissButton.addEventListener('click', () => {
+      alertDiv.classList.remove('visible');
+      messageList.innerHTML = '';
+    });
+  },
+
+  missingFieldsMessage(fields) {
+    return `Missing ${
+      fields.length > 1 ? fields.slice(0, -1).join(', ') : fields[0]
+    } ${fields.length > 1 ? `and ${fields.slice(-1)} fields.` : 'field.'}`;
+  },
+
+  nonExistent(...args) {
+    return args.every(param => param === null || typeof param === 'undefined');
+  },
+
+  responsiveNav() {
+    const menu = document.querySelector('.topbar__links');
+    const navToggle = document.querySelector('.topbar__toggle');
+
+    navToggle.addEventListener('click', () => {
+      menu.classList.toggle('active');
+      navToggle.classList.toggle('active');
+      navToggle.textContent = navToggle.classList.contains('active')
+        ? 'Close'
+        : 'Menu';
+    });
+  },
+
+  signUp(firstname, lastname, username, email, password) {
+    fetch(IR_HELPERS.API_SIGNUP_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        firstname,
+        lastname,
+        username,
+        email,
+        password,
+      }),
+    })
+      .then(res => res.json())
+      .then(async ({ data, errors }) => {
+        if (errors) {
+          IR_HELPERS.makeAuthFormMessages({ type: 'error', messages: errors });
+          return;
+        }
+
+        const [{ token, user }] = data;
+        localStorage.setItem('iReporter-token', token);
+        localStorage.setItem('iReporter-username', user.username);
+
+        IR_HELPERS.makeAuthFormMessages({
+          type: 'success',
+          messages: [
+            `${
+              user.username
+            } Signed up successfully. <br> Redirecting to dashboard`,
+          ],
+        });
+
+        setTimeout(
+          () =>
+            user.is_admin
+              ? IR_HELPERS.redirects.adminAuthSuccessRedirect()
+              : IR_HELPERS.redirects.authSuccessRedirect(),
+          600
+        );
+      })
+      .catch(() => {
+        IR_HELPERS.makeAuthFormMessages({
+          type: 'error',
+          messages: [
+            'Something went wrong. Please check your internet connection and try again.',
+          ],
+        });
+      });
+  },
+};
+
+window.IR_HELPERS = IR_HELPERS;

--- a/UI/views/signup.html
+++ b/UI/views/signup.html
@@ -26,6 +26,10 @@
         <h2 class="main-text">Signup</h2>
         <p class="sub-text">Start reporting</p>
       </div>
+      <div class="auth__messages">
+        <span class="auth__messages-dismiss">&rotimes;</span>
+        <ul class="auth__message-list"></ul>
+      </div>
       <div class="form-fields">
         <div class="form-field">
           <label for="reg-first-name">First Name</label>
@@ -61,17 +65,16 @@
   </main>
   <footer class="footer">
     <div class="links-wrapper ">
-      <a class="footer__link" href="home.html" target="_blank">Home</a>
-      <a class="footer__link" href="about.html" target="_blank">About</a>
-      <a class="footer__link" href="login.html" target="_blank">Login</a>
-      <a class="footer__link" href="register.html" target="_blank">Register</a>
+      <a class="footer__link" href="../../index.html">Home</a>
+      <a class="footer__link" href="#">About</a>
+      <a class="footer__link" href="login.html">Login</a>
     </div>
     <div>
       <p class="copyright">iReporter &copy;2018</p>
     </div>
   </footer>
 
-  <script src="../assets/js/nav.js"></script>
+  <script src="../assets/js/helpers.js"></script>
   <script src="../assets/js/auth.js"></script>
 </body>
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@sendgrid/mail": "^6.3.1",
     "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
     "debug": "^4.1.0",
     "dotenv": "^6.1.0",
     "eslint-config-airbnb": "^17.1.0",

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -7,7 +7,11 @@ export const validTypes = {
   comment: String(),
   status: ['under investigation', 'resolved', 'rejected', 'draft'],
   location: String(),
+  firstname: String(),
+  lastname: String(),
+  username: String(),
   password: String(),
+  phone: Number(),
   emailNotify: Boolean(),
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import cors from 'cors';
 import debug from 'debug';
 import morgan from 'morgan';
 import env from './config/envConf';
@@ -16,6 +17,7 @@ if (env.NODE_ENV === `production`) {
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(cors());
 
 routes(app);
 


### PR DESCRIPTION
**What does this PR do?**
Implements functionality for account creation from frontend

**Description of Task to be completed?**
- Enabled CORS on API server.
- Extended type validations for incoming request params.
- Created global IR_HELPERS object in frontend to hold shared code
- Consume API signup endpoint on frontend (Implement account creation functionality)

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-frontend-signup-implementation-163141848`
- run `npm run devstart`

 Test account creation by opening signup page in a browser and creating a new user account

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163141848](https://www.pivotaltracker.com/story/show/163141848)

Screenshots (if appropriate)

N/A

Questions:

N/A