### PR TITLE
#163164279 Filter all records by status/type

### DIFF
--- a/src/controllers/recordController.js
+++ b/src/controllers/recordController.js
@@ -3,6 +3,46 @@ import successResponse from '../helpers/successResponse';
 import handleError from '../helpers/errorHelper';
 
 export default {
+  fetchRecords(
+    {
+      params: { 0: recordType, 1: recordStatus },
+      records,
+    },
+    res
+  ) {
+    if (!recordType && !recordStatus) {
+      return successResponse(res, records);
+    }
+
+    if (!recordType && recordStatus) {
+      const filteredRecords = records.filter(
+        ({ status }) => status === recordStatus
+      );
+
+      return filteredRecords.length > 0
+        ? successResponse(res, filteredRecords)
+        : handleError(res, `No records marked as ${recordStatus}.`, 404);
+    }
+
+    if (recordType && recordStatus) {
+      const filteredRecords = records.filter(
+        ({ status, type }) => status === recordStatus && type === recordType
+      );
+
+      return filteredRecords.length > 0
+        ? successResponse(res, filteredRecords)
+        : handleError(
+            res,
+            `No ${recordType} records marked as ${recordStatus}.`,
+            404
+          );
+    }
+
+    return recordType
+      ? successResponse(res, records.filter(({ type }) => type === recordType))
+      : handleError(res, `No ${recordType} records found.`, 404);
+  },
+
   fetchStats(req, res) {
     Record.getAll().then(({ rowCount, rows: records }) =>
       rowCount > 0

--- a/src/middlewares/loadAllRecords.js
+++ b/src/middlewares/loadAllRecords.js
@@ -1,0 +1,12 @@
+import { Record } from '../models/records';
+import handleError from '../helpers/errorHelper';
+
+export default (req, res, next) =>
+  Record.getAll().then(({ rowCount, rows: records }) => {
+    if (rowCount > 1) {
+      req.records = records;
+      next();
+    } else {
+      handleError(res, 'No records created yet', 404);
+    }
+  });

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ import recordRouter from './records';
 import authRouter from './auth';
 import userRouter from './user';
 import apiSpec from '../../utils/swagger_spec.json';
+import handleError from '../helpers/errorHelper';
 
 const { serve, setup } = require('swagger-ui-express');
 
@@ -12,6 +13,9 @@ const router = app => {
   app.use(ROOT_URL, authRouter);
   app.use(ROOT_URL, userRouter);
   app.use('/api-docs', serve, setup(apiSpec));
+  app.use('*', (req, res) =>
+    handleError(res, 'Requested resource not found.', 404)
+  );
 };
 
 export default router;

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -10,10 +10,18 @@ import {
 import loadRecordByID from '../middlewares/loadRecordByID';
 import validUser from '../middlewares/validUser';
 import onlyAdmin from '../middlewares/onlyAdmin';
+import loadAllRecords from '../middlewares/loadAllRecords';
 
 const router = new Router();
 
 router.get('/records/stats', validUser, recordController.fetchStats);
+
+router.get(
+  /\/records\/?(intervention|red-flag)?\/?(under%20investigation|resolved|rejected|draft)?\/?$/,
+  validUser,
+  loadAllRecords,
+  recordController.fetchRecords
+);
 
 router.post(
   '/red-flags',

--- a/test/records.js
+++ b/test/records.js
@@ -47,6 +47,39 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           });
       });
 
+      it('Returns error response when no records match filters', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/red-flag`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(typeof body.errors[0]).eq('string');
+          });
+
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/resolved`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(typeof body.errors[0]).eq('string');
+          });
+
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/red-flag/draft`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(typeof body.errors[0]).eq('string');
+            done();
+          });
+      });
+
       it('Returns an empty array when no records exist', done => {
         chai
           .request(server)
@@ -673,6 +706,99 @@ export default ({ server, chai, expect, ROOT_URL }) => {
         .request(server)
         .get(`${ROOT_URL}/user/recordstats`)
         .set('authorization', `Bearer ${adminToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(404);
+          expect(body.errors).to.be.an.instanceof(Array);
+          expect(body.errors[0]).to.be.a('string');
+          done();
+        });
+    });
+  });
+
+  describe('Filter Records', () => {
+    it('Should get all records when no filters are applied', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body.data[0]).to.be.an('object');
+
+          done();
+        });
+    });
+
+    it('Should get all intervention records', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records/intervention`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body.data[0]).to.be.an('object');
+
+          done();
+        });
+    });
+
+    it('Should get all resolved records', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records/resolved`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body.data[0]).to.be.an('object');
+
+          done();
+        });
+    });
+
+    it('Should get all resolved red-flag records', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records/red-flag/resolved`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(200);
+          expect(body.data[0]).to.be.an('object');
+
+          done();
+        });
+    });
+
+    it('Should return error message for invalid status', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records/rejected`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(404);
+          expect(body.errors).to.be.an.instanceof(Array);
+          expect(body.errors[0]).to.be.a('string');
+          done();
+        });
+    });
+
+    it('Should return error message for invalid status', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records/resolving`)
+        .set('authorization', `Bearer ${authToken}`)
+        .end((err, { body, status }) => {
+          expect(status).eq(404);
+          expect(body.errors).to.be.an.instanceof(Array);
+          expect(body.errors[0]).to.be.a('string');
+          done();
+        });
+    });
+
+    it('Should return error message for invalid type', done => {
+      chai
+        .request(server)
+        .get(`${ROOT_URL}/records/white-flag/`)
+        .set('authorization', `Bearer ${authToken}`)
         .end((err, { body, status }) => {
           expect(status).eq(404);
           expect(body.errors).to.be.an.instanceof(Array);


### PR DESCRIPTION
**What does this PR do?**
Implements functionality to fetch filtered records by sending `GET` requests to `/records/?<type>/?<status>`

**Description of Task to be completed?**
- Add middleware to load all records onto request object
- Add tests to validate record filter functionality
- Implement functionality to enable filtering records by type/status

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-fetch-filtered-records-163164279`
- run `npm run devstart`

 Test record fetch filters by creating some records, then send `GET` requests `${ROOT_URL}/records/?<type>/?<status>`
where `${ROOT_URL}` is the API prefix URL on your local machine.

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163164279](https://www.pivotaltracker.com/story/show/163164279)

Screenshots (if appropriate)

N/A

Questions:

N/A