### PR TITLE
#163167356 User can get username by ID

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,4 +1,5 @@
 import { Record } from '../models/records';
+import { User } from '../models/users';
 import successResponse from '../helpers/successResponse';
 import handleError from '../helpers/errorHelper';
 
@@ -34,5 +35,18 @@ export default {
         } else handleError(res, 'No records found for user', 404);
       } else handleError(res, 'No records found', 404);
     });
+  },
+
+  getUsernameByID(
+    {
+      params: { id },
+    },
+    res
+  ) {
+    return User.getUsernameByID(id)
+      .then(({ rows: [{ username }] }) =>
+        successResponse(res, { username }, 200)
+      )
+      .catch(() => handleError(res, `Cannot find user with id ${id}.`, 404));
   },
 };

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -38,6 +38,11 @@ export class User {
     return db.query(...queryString);
   }
 
+  static getUsernameByID(id) {
+    const queryString = [`SELECT username FROM users WHERE id = $1`, [id]];
+    return db.query(...queryString);
+  }
+
   save() {
     const queryString = [
       `INSERT INTO users(firstname,

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -5,5 +5,6 @@ import validUser from '../middlewares/validUser';
 const router = new Router();
 
 router.get('/user/recordstats', validUser, userController.fetchStats);
+router.get('/user/id2name/:id', validUser, userController.getUsernameByID);
 
 export default router;

--- a/test/users.js
+++ b/test/users.js
@@ -78,5 +78,46 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           });
       });
     });
+
+    describe('Get username by ID', () => {
+      let authToken;
+
+      before(done => {
+        chai
+          .request(server)
+          .post(`${ROOT_URL}/auth/login`)
+          .send(user.token)
+          .end((err, { body }) => {
+            [{ token: authToken }] = body.data;
+            done();
+          });
+      });
+
+      it('Should get a username by providing a valid user ID', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/id2name/2`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data).to.be.an.instanceof(Array);
+            expect(body.data[0]).to.be.an('object');
+            done();
+          });
+      });
+
+      it('Should get an error response when valid user ID supplied', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/id2name/6`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.a('string');
+            done();
+          });
+      });
+    });
   });
 };


### PR DESCRIPTION
**What does this PR do?**
Implements functionality to allow users to get the usernames of other users by supplying  their ID  in GET requests to `/user/id2name/<id>`

**Description of Task to be completed?**
- Add tests to validate fetching usernames by ID
- Implement username fetching by ID.

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-fetch-username-by-id-163167356`
- run `npm run devstart`

 Test record statistics fetching by creating some records, then send `GET` requests `${ROOT_URL}/user/id2name/<id>`
where `${ROOT_URL}` is the API prefix URL on your local machine.

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163167356](https://www.pivotaltracker.com/story/show/163167356)

Screenshots (if appropriate)

N/A

Questions:

N/A