### PR TITLE
#163209501 Filter own records by status/type

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -4,6 +4,54 @@ import successResponse from '../helpers/successResponse';
 import handleError from '../helpers/errorHelper';
 
 export default {
+  fetchRecords(
+    {
+      params: { 0: recordType, 1: recordStatus },
+      records,
+      user: { id: userID },
+    },
+    res
+  ) {
+    const userRecords = records.filter(
+      ({ created_by: creator }) => creator === userID
+    );
+
+    if (!recordType && !recordStatus) {
+      return successResponse(res, userRecords);
+    }
+
+    if (!recordType && recordStatus) {
+      const filteredRecords = userRecords.filter(
+        ({ status }) => status === recordStatus
+      );
+
+      return filteredRecords.length > 0
+        ? successResponse(res, filteredRecords)
+        : handleError(res, `No records marked as ${recordStatus}.`, 404);
+    }
+
+    if (recordType && recordStatus) {
+      const filteredRecords = userRecords.filter(
+        ({ status, type }) => status === recordStatus && type === recordType
+      );
+
+      return filteredRecords.length > 0
+        ? successResponse(res, filteredRecords)
+        : handleError(
+            res,
+            `No ${recordType} records marked as ${recordStatus}.`,
+            404
+          );
+    }
+
+    return recordType
+      ? successResponse(
+          res,
+          userRecords.filter(({ type }) => type === recordType)
+        )
+      : handleError(res, `No ${recordType} records found.`, 404);
+  },
+
   fetchStats(
     {
       user: { id: userID },

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -17,7 +17,7 @@ const router = new Router();
 router.get('/records/stats', validUser, recordController.fetchStats);
 
 router.get(
-  /\/records\/?(intervention|red-flag)?\/?(under%20investigation|resolved|rejected|draft)?\/?$/,
+  /^\/records\/?(intervention|red-flag)?\/?(under%20investigation|resolved|rejected|draft)?\/?$/,
   validUser,
   loadAllRecords,
   recordController.fetchRecords

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,10 +1,17 @@
 import { Router } from 'express';
 import userController from '../controllers/userController';
 import validUser from '../middlewares/validUser';
+import loadAllRecords from '../middlewares/loadAllRecords';
 
 const router = new Router();
 
 router.get('/user/recordstats', validUser, userController.fetchStats);
 router.get('/user/id2name/:id', validUser, userController.getUsernameByID);
+router.get(
+  /^\/user\/records\/?(intervention|red-flag)?\/?(under%20investigation|resolved|rejected|draft)?\/?$/,
+  validUser,
+  loadAllRecords,
+  userController.fetchRecords
+);
 
 export default router;

--- a/test/records.js
+++ b/test/records.js
@@ -716,95 +716,190 @@ export default ({ server, chai, expect, ROOT_URL }) => {
   });
 
   describe('Filter Records', () => {
-    it('Should get all records when no filters are applied', done => {
-      chai
-        .request(server)
-        .get(`${ROOT_URL}/records`)
-        .set('authorization', `Bearer ${authToken}`)
-        .end((err, { body, status }) => {
-          expect(status).eq(200);
-          expect(body.data[0]).to.be.an('object');
+    describe('All users', () => {
+      it('Should get all records when no filters are applied', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
 
-          done();
-        });
+            done();
+          });
+      });
+
+      it('Should get all intervention records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/intervention`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
+
+            done();
+          });
+      });
+
+      it('Should get all resolved records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/resolved`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
+
+            done();
+          });
+      });
+
+      it('Should get all resolved red-flag records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/red-flag/resolved`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
+
+            done();
+          });
+      });
+
+      it('Should return error message for status with no records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/rejected`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.a('string');
+            done();
+          });
+      });
+
+      it('Should return error message for invalid status', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/resolving`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.a('string');
+            done();
+          });
+      });
+
+      it('Should return error message for invalid type', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/records/white-flag/`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.a('string');
+            done();
+          });
+      });
     });
 
-    it('Should get all intervention records', done => {
-      chai
-        .request(server)
-        .get(`${ROOT_URL}/records/intervention`)
-        .set('authorization', `Bearer ${authToken}`)
-        .end((err, { body, status }) => {
-          expect(status).eq(200);
-          expect(body.data[0]).to.be.an('object');
+    describe('Own profile', () => {
+      it('Should get all records when no filters are applied', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/records`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
 
-          done();
-        });
-    });
+            done();
+          });
+      });
 
-    it('Should get all resolved records', done => {
-      chai
-        .request(server)
-        .get(`${ROOT_URL}/records/resolved`)
-        .set('authorization', `Bearer ${authToken}`)
-        .end((err, { body, status }) => {
-          expect(status).eq(200);
-          expect(body.data[0]).to.be.an('object');
+      it('Should get all intervention records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/records/intervention`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
 
-          done();
-        });
-    });
+            done();
+          });
+      });
 
-    it('Should get all resolved red-flag records', done => {
-      chai
-        .request(server)
-        .get(`${ROOT_URL}/records/red-flag/resolved`)
-        .set('authorization', `Bearer ${authToken}`)
-        .end((err, { body, status }) => {
-          expect(status).eq(200);
-          expect(body.data[0]).to.be.an('object');
+      it('Should get all resolved records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/records/resolved`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
 
-          done();
-        });
-    });
+            done();
+          });
+      });
 
-    it('Should return error message for invalid status', done => {
-      chai
-        .request(server)
-        .get(`${ROOT_URL}/records/rejected`)
-        .set('authorization', `Bearer ${authToken}`)
-        .end((err, { body, status }) => {
-          expect(status).eq(404);
-          expect(body.errors).to.be.an.instanceof(Array);
-          expect(body.errors[0]).to.be.a('string');
-          done();
-        });
-    });
+      it('Should get all resolved red-flag records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/records/red-flag/resolved`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body.data[0]).to.be.an('object');
 
-    it('Should return error message for invalid status', done => {
-      chai
-        .request(server)
-        .get(`${ROOT_URL}/records/resolving`)
-        .set('authorization', `Bearer ${authToken}`)
-        .end((err, { body, status }) => {
-          expect(status).eq(404);
-          expect(body.errors).to.be.an.instanceof(Array);
-          expect(body.errors[0]).to.be.a('string');
-          done();
-        });
-    });
+            done();
+          });
+      });
 
-    it('Should return error message for invalid type', done => {
-      chai
-        .request(server)
-        .get(`${ROOT_URL}/records/white-flag/`)
-        .set('authorization', `Bearer ${authToken}`)
-        .end((err, { body, status }) => {
-          expect(status).eq(404);
-          expect(body.errors).to.be.an.instanceof(Array);
-          expect(body.errors[0]).to.be.a('string');
-          done();
-        });
+      it('Should return error message for status with no records', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/records/rejected`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.a('string');
+            done();
+          });
+      });
+
+      it('Should return error message for invalid status', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/records/resolving`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.a('string');
+            done();
+          });
+      });
+
+      it('Should return error message for invalid type', done => {
+        chai
+          .request(server)
+          .get(`${ROOT_URL}/user/records/white-flag/`)
+          .set('authorization', `Bearer ${authToken}`)
+          .end((err, { body, status }) => {
+            expect(status).eq(404);
+            expect(body.errors).to.be.an.instanceof(Array);
+            expect(body.errors[0]).to.be.a('string');
+            done();
+          });
+      });
     });
   });
 };


### PR DESCRIPTION
**What does this PR do?**
Implements functionality that allows users  filter their own records by sending `GET` requests to `/user/records/?<type>/?<status>`

**Description of Task to be completed?**
- Add tests to validate record filter functionality
- Implement functionality to enable filtering _own_ records by type/status

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-filter-own-records-163209501`
- run `npm run devstart`

 Test record fetch filters by creating some records, then send `GET` requests `${ROOT_URL}/user/records/?<type>/?<status>`
where `${ROOT_URL}` is the API prefix URL on your local machine.

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163209501](https://www.pivotaltracker.com/story/show/163209501)

Screenshots (if appropriate)

N/A

Questions:

N/A