### PR TITLE
#163269435 Fix email notification validation and logic

### DIFF
--- a/UI/assets/js/helpers.js
+++ b/UI/assets/js/helpers.js
@@ -114,7 +114,7 @@ const IR_HELPERS = {
         title,
         comment,
         location,
-        ...(emailNotify ? { emailNotify } : {}),
+        emailNotify: JSON.stringify(emailNotify),
       }),
     })
       .then(res => res.json())

--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -6,10 +6,7 @@ import mailHelper from '../helpers/mailHelper';
 const createRecord = ({ body, user }, res) =>
   new Intervention({
     ...body,
-    ...{
-      createdBy: user.id,
-      emailNotify: body.emailNotify || user.emailNotify,
-    },
+    ...{ createdBy: user.id },
   })
     .save()
     .then(({ rows }) =>

--- a/src/controllers/redFlagController.js
+++ b/src/controllers/redFlagController.js
@@ -6,10 +6,7 @@ import mailHelper from '../helpers/mailHelper';
 const createRecord = ({ body, user }, res) =>
   new RedFlag({
     ...body,
-    ...{
-      createdBy: user.id,
-      emailNotify: body.emailNotify || user.emailNotify,
-    },
+    ...{ createdBy: user.id },
   })
     .save()
     .then(({ rows }) =>

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -85,9 +85,14 @@ export const verifyRequestTypes = (req, res, next) => {
   const isEmpty = stringParam => stringParam === '';
 
   Object.keys(body).forEach(param => {
-    if (body[param] !== undefined && typeof body[param] === 'string') {
-      body[param] = body[param].trim();
-      switch (param.trim()) {
+    if (
+      body[param] !== undefined &&
+      (typeof body[param] === 'string' || typeof body[param] === 'boolean')
+    ) {
+      body[param] =
+        typeof body[param] === 'string' ? body[param].trim() : body[param];
+
+      switch (param) {
         case 'email':
           if (isEmpty(body[param]) || !/^.+@.+\..+$/.test(body[param])) {
             errors.push(`cannot parse invalid email "${body[param]}".`);
@@ -98,7 +103,9 @@ export const verifyRequestTypes = (req, res, next) => {
             isEmpty(body[param]) ||
             typeof jsonParse(body[param]) !== typeof validTypes[param]
           ) {
-            errors.push(`emailNotify must be a boolean`);
+            errors.push(
+              `Invalid value for ${param}: Expected ${typeof validTypes[param]}`
+            );
           }
           break;
         case 'status':


### PR DESCRIPTION
**What does this PR do?**
Implements record creation from frontend

**Description of Task to be completed?**
- Extend type checker to test for booleans (to avoid any weirdness)
- Discard checking incoming email notification param against unimplemented(currently) user toggle
- Cast param value to a string before sending the request from frontend.

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `bg-fix-emailnotify-validator-163269435`
- run `npm run devstart`

 Test record creation email notification toggle by clicking on the new record link on the user dashboard

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163269435](https://www.pivotaltracker.com/story/show/163269435)

Screenshots (if appropriate)

N/A

Questions:

N/A