### PR TITLE
#163281354 Implement frontend record updating

### DIFF
--- a/UI/assets/js/dash.js
+++ b/UI/assets/js/dash.js
@@ -18,6 +18,7 @@ this.addEventListener('load', async () => {
     notify,
     populateDashboardStats,
     populateDashboardFeed,
+    populateEditForm,
     resetLocationFields,
     responsiveNav,
     initUserWidget,
@@ -36,6 +37,8 @@ this.addEventListener('load', async () => {
     dashboard && classList.contains('dashboard--user-profile');
   const recordCreationDash =
     dashboard && dashboard.querySelector('.create-edit-form--create');
+  const recordEditDash =
+    dashboard && dashboard.querySelector('.create-edit-form--edit');
 
   const state = {
     detailmodalOpened: false,
@@ -145,5 +148,55 @@ this.addEventListener('load', async () => {
             emailNotify: emailNotify.checked,
           });
     });
+  }
+
+  if (recordEditDash) {
+    await populateDashboardStats({
+      widgetList: getStatCounters(dashboard),
+      scope: 'user',
+    });
+
+    initAsideListeners(dashboard);
+
+    const { search: queryString } = window.location;
+    try {
+      if (
+        queryString &&
+        ((new URLSearchParams(queryString).has('type') &&
+          new URLSearchParams(queryString).has('id')) ||
+          (queryString
+            .substring(1)
+            .split('&')[0]
+            .split('=')[0] === 'type' &&
+            queryString
+              .substring(1)
+              .split('&')[1]
+              .split('=')[0] === 'id'))
+      ) {
+        const recordID =
+          new URLSearchParams(queryString).get('id') ||
+          queryString
+            .substring(1)
+            .split('&')[1]
+            .split('=')[1];
+
+        const recordType =
+          new URLSearchParams(queryString).get('type') ||
+          queryString
+            .substring(1)
+            .split('&')[0]
+            .split('=')[1];
+
+        if (recordType && typeof JSON.parse(recordID) === 'number')
+          populateEditForm(recordType, recordID);
+        else throw Error('invalid record path');
+      }
+    } catch (error) {
+      displayNotification({
+        type: 'Error',
+        title: 'Error',
+        message: 'No record to edit',
+      });
+    }
   }
 });

--- a/UI/assets/js/helpers.js
+++ b/UI/assets/js/helpers.js
@@ -19,6 +19,11 @@ const IR_HELPERS = {
       name: 'Error',
       message: 'No records found',
     },
+    mapLoad: {
+      name: 'Error loading location Information',
+      message:
+        'There was a problem loading the address/map. Please check your internet connection',
+    },
   },
 
   redirects: {
@@ -31,7 +36,8 @@ const IR_HELPERS = {
           ),
     back: ({ queryString = '' } = {}) =>
       document.referrer &&
-      new URL(document.referrer).hostname === window.location.hostname
+      new URL(document.referrer).hostname === window.location.hostname &&
+      document.referrer.split('?')[0] !== window.location.href.split('?')[0]
         ? window.location.assign(document.referrer + queryString)
         : window.location.assign(`profile.html${queryString}`),
     redirectTo: url => window.location.assign(url),
@@ -142,7 +148,7 @@ const IR_HELPERS = {
   displayCoords(coordinateString) {
     const coordDisplay = document.querySelector('.create-edit-form__geocodes');
     const fieldsBelow = document.querySelectorAll(
-      '.form-field--media, .btn--submit'
+      '.form-field--media, .form-field--notification, .btn--submit'
     );
 
     coordDisplay.hidden = false;
@@ -221,7 +227,11 @@ const IR_HELPERS = {
     const dismissNotification = notificationElement => {
       notificationElement.classList.remove('visible');
       setTimeout(() => {
-        notificationWrapper.removeChild(notificationElement);
+        if (
+          notificationElement &&
+          notificationWrapper.contains(notificationElement)
+        )
+          notificationWrapper.removeChild(notificationElement);
       }, 200);
 
       return !notificationWrapper.hasChildNodes()
@@ -252,6 +262,47 @@ const IR_HELPERS = {
     setTimeout(() => {
       dismissNotification(notification);
     }, timeout || 5000);
+  },
+
+  async editRecord(path, fields) {
+    const responsePromises = await Promise.all(
+      Object.keys(fields).map(field =>
+        IR_HELPERS.patchRecord(path, field, fields[field])
+      )
+    ).then(res => res.map(each => each.json()));
+
+    const { errors, messages } = await responsePromises.reduce(
+      async (parsedObjectPromise, response) => {
+        const parsedObject = await parsedObjectPromise;
+        const { data, errors: responseErrors } = await response;
+        let message;
+
+        if (data) [{ message }] = data;
+
+        return responseErrors
+          ? Object.assign(parsedObject, {
+              errors: [...parsedObject.errors, ...responseErrors],
+            })
+          : Object.assign(parsedObject, {
+              messages: [...parsedObject.messages, message],
+            });
+      },
+      { errors: [], messages: [] }
+    );
+
+    return errors.length
+      ? IR_HELPERS.displayNotification({
+          message: errors,
+          title: 'Error Updating record',
+        })
+      : messages.length
+      ? IR_HELPERS.redirects.back({
+          queryString: `?title=success&type=success&message=${messages
+            .join('<br>')
+            .replace(/\s/g, '+')
+            .replace(/#/, '%23')}`,
+        })
+      : null;
   },
 
   exists(...args) {
@@ -355,6 +406,19 @@ const IR_HELPERS = {
         : typeFilter || state.typeFilter;
 
     return { status, type };
+  },
+
+  findChangedFields(fieldPairs) {
+    const changedFields = [];
+
+    Object.keys(fieldPairs).forEach(field =>
+      fieldPairs[field][0] !== fieldPairs[field][1] &&
+      fieldPairs[field][1] !== ''
+        ? changedFields.push({ [field]: fieldPairs[field][1] })
+        : null
+    );
+
+    return changedFields;
   },
 
   findMissingFields(fields) {
@@ -555,9 +619,8 @@ const IR_HELPERS = {
     } catch (error) {
       IR_HELPERS.displayNotification({
         type: 'error',
-        title: 'Error loading map',
-        message:
-          'There was a problem loading the map. Please check your internet connection',
+        title: IR_HELPERS.errors.mapLoad.name,
+        message: IR_HELPERS.errors.mapLoad.message,
       });
     }
   },
@@ -697,7 +760,7 @@ const IR_HELPERS = {
         modals.forEach(modal => {
           if (modal) {
             IR_HELPERS.fetchRecordByid(recordPath.value).then(
-              async ({ errors, record }) => {
+              ({ errors, record }) => {
                 if (errors) {
                   IR_HELPERS.displayNotification({
                     type: 'error',
@@ -706,7 +769,7 @@ const IR_HELPERS = {
                     timeout: 1000,
                   });
                 } else if (record) {
-                  await IR_HELPERS.populateModal({
+                  IR_HELPERS.populateModal({
                     modal,
                     record,
                     state,
@@ -743,57 +806,79 @@ const IR_HELPERS = {
   notify() {
     const { search: queryString } = window.location;
 
-    if (queryString)
-      window.history.pushState(
-        {},
-        document.title,
-        window.location.href.split('?')[0]
-      );
-    if (
-      queryString &&
-      ((new URLSearchParams(queryString).has('type') &&
-        new URLSearchParams(queryString).has('title') &&
-        new URLSearchParams(queryString).has('message')) ||
-        (queryString
-          .substring(1)
-          .split('&')[0]
-          .split('=')[0] === 'type' &&
+    try {
+      if (
+        queryString &&
+        ((new URLSearchParams(queryString).has('type') &&
+          new URLSearchParams(queryString).has('title') &&
+          new URLSearchParams(queryString).has('message')) ||
+          (queryString
+            .substring(1)
+            .split('&')[0]
+            .split('=')[0] === 'type' &&
+            queryString
+              .substring(1)
+              .split('&')[1]
+              .split('=')[0] === 'title' &&
+            queryString
+              .substring(1)
+              .split('&')[1]
+              .split('=')[0] === 'message'))
+      ) {
+        const type =
+          new URLSearchParams(queryString).get('type') ||
+          queryString
+            .substring(1)
+            .split('&')[0]
+            .split('=')[1];
+        const title =
+          new URLSearchParams(queryString).get('title').replace(/\+/g, ' ') ||
           queryString
             .substring(1)
             .split('&')[1]
-            .split('=')[0] === 'title' &&
+            .split('=')[1]
+            .replace(/\+/g, ' ');
+        const message =
+          new URLSearchParams(queryString).get('message').replace(/\+/g, ' ') ||
           queryString
             .substring(1)
-            .split('&')[1]
-            .split('=')[0] === 'message'))
-    ) {
-      const type =
-        new URLSearchParams(queryString).get('type') ||
-        queryString
-          .substring(1)
-          .split('&')[0]
-          .split('=')[1];
-      const title =
-        new URLSearchParams(queryString).get('title').replace(/\+/g, ' ') ||
-        queryString
-          .substring(1)
-          .split('&')[1]
-          .split('=')[1]
-          .replace(/\+/g, ' ');
-      const message =
-        new URLSearchParams(queryString).get('message').replace(/\+/g, ' ') ||
-        queryString
-          .substring(1)
-          .split('&')[2]
-          .split('=')[1]
-          .replace(/\+/g, ' ');
+            .split('&')[2]
+            .split('=')[1]
+            .replace(/\+/g, ' ');
 
-      IR_HELPERS.displayNotification({
-        message,
-        type,
-        title,
-      });
+        if (type && title && message)
+          window.history.pushState(
+            {},
+            document.title,
+            window.location.href.split('?')[0]
+          );
+
+        IR_HELPERS.displayNotification({
+          message,
+          type,
+          title,
+        });
+      }
+    } catch ({ name }) {
+      // pass
     }
+  },
+
+  patchRecord(recordPath, field, value) {
+    let requestUrl = IR_HELPERS.buildFetchPath({
+      singleRecordPath: recordPath,
+    });
+    requestUrl += `/${field.toLowerCase()}`;
+
+    return fetch(requestUrl, {
+      method: 'PATCH',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${IR_HELPERS.getToken()}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ [field]: value }),
+    });
   },
 
   async populateDashboardFeed({
@@ -941,7 +1026,93 @@ const IR_HELPERS = {
     }
   },
 
-  async populateModal({ modal, record, state }) {
+  async populateEditForm(recordType, id) {
+    const form = document.querySelector('.create-edit-form--edit');
+    const titleField = form.querySelector('.create-edit-form__record-title');
+    const commentField = form.querySelector('.create-edit-form__comment');
+    const locationField = form.querySelector('.create-edit-form__location');
+    const typeSelector = form.querySelector('.create-edit-form__type');
+    const locationReset = document.querySelector(
+      '.create-edit-form__location-reset'
+    );
+    const emailNotify = form.querySelector(
+      '.create-edit-form__email-notification'
+    );
+    form.addEventListener('submit', e => e.preventDefault());
+
+    try {
+      const { errors, record } = await IR_HELPERS.fetchRecordByid(
+        `${recordType}s/${id}`
+      );
+
+      if (errors) {
+        IR_HELPERS.displayNotification({
+          type: 'error',
+          message: errors,
+        });
+        return;
+      }
+
+      if (record) {
+        const {
+          title,
+          comment,
+          location,
+          type,
+          email_notify: emailUpdates,
+        } = record;
+
+        titleField.value = title;
+        commentField.value = comment;
+        emailNotify.checked = emailUpdates;
+        typeSelector.value = type;
+
+        if (location) {
+          locationField.value = await IR_HELPERS.reverseGeocode(
+            IR_HELPERS.flipLocationString(location)
+          );
+
+          IR_HELPERS.displayCoords(location);
+        }
+
+        IR_HELPERS.autoCompleteHook(locationField);
+        locationReset.addEventListener('click', () =>
+          IR_HELPERS.resetLocationFields()
+        );
+      }
+
+      form.addEventListener('submit', e => {
+        e.preventDefault();
+        const { comment, location, email_notify: emailUpdates } = record;
+        const recordPath = `${record.type}s/${record.id}`;
+
+        const changedFields = IR_HELPERS.findChangedFields({
+          comment: [comment, commentField.value],
+          location: [location, IR_HELPERS.getLocationString()],
+          emailNotify: [emailUpdates, emailNotify.checked],
+        });
+
+        return changedFields.length
+          ? IR_HELPERS.editRecord(
+              recordPath,
+              changedFields.reduce((acc, curr) => ({ ...acc, ...curr }), {})
+            )
+          : IR_HELPERS.displayNotification({
+              type: 'success',
+              title: `Editing ${recordType} #${id}`,
+              message: 'No edits made.',
+            });
+      });
+    } catch ({ name, message }) {
+      IR_HELPERS.displayNotification({
+        type: 'error',
+        title: name,
+        message,
+      });
+    }
+  },
+
+  populateModal({ modal, record, state }) {
     const modalHeader = modal.querySelector('.detail-modal__type-id');
     const locationMap = modal.querySelector('.detail-modal__map');
     const recordTitle = modal.querySelector('.detail-modal__title');
@@ -1046,7 +1217,7 @@ const IR_HELPERS = {
     const coordDisplay = document.querySelector('.create-edit-form__geocodes');
     const locationInput = document.querySelector('.create-edit-form__location');
     const fieldsBelow = document.querySelectorAll(
-      '.form-field--media, .btn--submit'
+      '.form-field--media, .form-field--notification, .btn--submit'
     );
 
     coordDisplay.hidden = true;
@@ -1068,6 +1239,20 @@ const IR_HELPERS = {
         ? 'Close'
         : 'Menu';
     });
+  },
+
+  async reverseGeocode(locationString) {
+    try {
+      const apiRes = await fetch(
+        `https://maps.googleapis.com/maps/api/geocode/json?latlng=${locationString}&key=AIzaSyApBXNZ8DfcSajnuuNOEMWNNH0eIZdBtws`
+      );
+      const { results } = await apiRes.json();
+      const [{ formatted_address: mostApproximateLocation }] = results;
+
+      return mostApproximateLocation;
+    } catch (error) {
+      throw IR_HELPERS.errors.mapLoad;
+    }
   },
 
   setLocationString(coordinateString) {

--- a/UI/views/edit-record.html
+++ b/UI/views/edit-record.html
@@ -4,7 +4,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Edit Record | iReporter</title>
   <link rel="stylesheet" href="../assets/css/style.css">
 </head>
@@ -68,8 +67,7 @@
               <label for="edit-location">Location of Event</label>
               <input class="create-edit-form__location" type="text" id="edit-location">
               <button type="button" class="create-edit-form__location-reset btn">Clear</button>
-              <p class="create-edit-form__geocodes  hidden">
-              </p>
+              <p class="create-edit-form__geocodes  hidden"></p>
             </div>
             <div class="form-field form-field--media">
               <label for="edit-media">Media:
@@ -77,6 +75,11 @@
                 <small class="create-edit-form__media-hint">You can add multiple videos & images</small>
               </label>
               <input class="create-edit-form__media" type="file" id="edit-media" multiple disabled>
+            </div>
+            <div title="Check to recieve notifications when an admin changes the status of this record" class="form-field form-field--notification">
+              <label for="edit-email-notification"> Email notifications?
+              </label>
+              <input class="create-edit-form__email-notification" type="checkbox" id="create-email-notification">
             </div>
             <button class="btn btn--submit" type="submit">Save Changes</button>
           </div>
@@ -90,8 +93,10 @@
     </div>
   </footer>
 
+  <div class="notification-wrapper"></div>
+
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyApBXNZ8DfcSajnuuNOEMWNNH0eIZdBtws&libraries=places"></script>
-  <script src="../assets/js/nav.js"></script>
+  <script src="../assets/js/helpers.js"></script>
   <script src="../assets/js/dash.js"></script>
 </body>
 

--- a/UI/views/new-record.html
+++ b/UI/views/new-record.html
@@ -76,7 +76,7 @@
               </label>
               <input class="create-edit-form__media" type="file" id="create-media" multiple>
             </div>
-            <div title="Check to recieve notifications when an admin changes the status of this record" class="form-field">
+            <div title="Check to recieve email notifications when an admin changes the status of this record" class="form-field form-field--notification">
               <label for="create-email-notification"> Email notifications?
               </label>
               <input class="create-edit-form__email-notification" type="checkbox" id="create-email-notification">

--- a/src/controllers/interventionController.js
+++ b/src/controllers/interventionController.js
@@ -27,6 +27,33 @@ const fetchAllRecords = (req, res) =>
 
 const fetchRecordByID = ({ record }, res) => successResponse(res, record);
 
+const toggleEmailNotifications = ({ body, record, user }, res) => {
+  if (
+    record.email_notify !== body.emailNotify &&
+    record.created_by === user.id
+  ) {
+    Intervention.patch(record.id, body.emailNotify, 'email_notify').then(
+      ({ rows: [patchedRecord] }) => {
+        successResponse(res, {
+          id: patchedRecord.id,
+          message: `Email notifications turned ${
+            patchedRecord.email_notify ? 'on' : 'off'
+          } for Intervention #${patchedRecord.id}`,
+          patchedRecord,
+        });
+      }
+    );
+  } else if (record.created_by !== user.id) {
+    handleError(
+      res,
+      `Cannot toggle Email notifications of intervention record you did not create`,
+      403
+    );
+  } else {
+    successResponse(res, {}, 304);
+  }
+};
+
 const updateComment = ({ body, editable, record, user }, res) => {
   if (
     editable &&
@@ -130,6 +157,7 @@ export default {
   createRecord,
   fetchAllRecords,
   fetchRecordByID,
+  toggleEmailNotifications,
   updateComment,
   updateLocation,
   updateStatus,

--- a/src/controllers/redFlagController.js
+++ b/src/controllers/redFlagController.js
@@ -27,6 +27,33 @@ const fetchAllRecords = (req, res) =>
 
 const fetchRecordByID = ({ record }, res) => successResponse(res, record);
 
+const toggleEmailNotifications = ({ body, record, user }, res) => {
+  if (
+    record.email_notify !== body.emailNotify &&
+    record.created_by === user.id
+  ) {
+    RedFlag.patch(record.id, body.emailNotify, 'email_notify').then(
+      ({ rows: [patchedRecord] }) => {
+        successResponse(res, {
+          id: patchedRecord.id,
+          message: `Email notifications turned ${
+            patchedRecord.email_notify ? 'on' : 'off'
+          } for Red-Flag #${patchedRecord.id}`,
+          patchedRecord,
+        });
+      }
+    );
+  } else if (record.created_by !== user.id) {
+    handleError(
+      res,
+      `Cannot toggle Email notifications of red-flag record you did not create`,
+      403
+    );
+  } else {
+    successResponse(res, {}, 304);
+  }
+};
+
 const updateComment = ({ body, editable, record, user }, res) => {
   if (
     editable &&
@@ -126,6 +153,7 @@ export default {
   createRecord,
   fetchAllRecords,
   fetchRecordByID,
+  toggleEmailNotifications,
   updateComment,
   updateLocation,
   updateStatus,

--- a/src/middlewares/sanitizeRequest.js
+++ b/src/middlewares/sanitizeRequest.js
@@ -31,6 +31,7 @@ export const checkRequired = paramToCheck => (req, res, next) => {
     case 'comment':
     case 'location':
     case 'status':
+    case 'emailNotify':
       errorIfMissing([paramToCheck]);
       break;
     case 'record':
@@ -106,7 +107,7 @@ export const verifyRequestTypes = (req, res, next) => {
             errors.push(
               `Invalid value for ${param}: Expected ${typeof validTypes[param]}`
             );
-          }
+          } else body[param] = JSON.parse(body[param]);
           break;
         case 'status':
           if (

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -69,6 +69,15 @@ router.patch(
   redFlagController.updateLocation
 );
 
+router.patch(
+  '/red-flags/:id/emailnotify',
+  validUser,
+  checkRequired('emailNotify'),
+  verifyRequestTypes,
+  loadRecordByID('red-flag'),
+  redFlagController.toggleEmailNotifications
+);
+
 router.delete(
   '/red-flags/:id',
   validUser,
@@ -115,6 +124,15 @@ router.patch(
 );
 
 router.patch(
+  '/interventions/:id/emailnotify',
+  validUser,
+  checkRequired('emailNotify'),
+  verifyRequestTypes,
+  loadRecordByID('intervention'),
+  interventionController.toggleEmailNotifications
+);
+
+router.patch(
   '/interventions/:id/status',
   validUser,
   onlyAdmin,
@@ -128,7 +146,7 @@ router.delete(
   '/interventions/:id',
   validUser,
   loadRecordByID('intervention'),
-  redFlagController.deleteRecordByID
+  interventionController.deleteRecordByID
 );
 
 export default router;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,6 +5,7 @@ export const recordPatches = {
   location: '-94.68589980000002, 46.729553',
   status: 'resolved',
   invalidStatus: 'gibberish',
+  emailNotify: true,
 };
 
 export const records = {
@@ -13,6 +14,7 @@ export const records = {
     type: 'red-flag',
     location: '101.68685499999992,3.139003',
     comment: 'I smell something fishy',
+    emailNotify: false,
   },
   sampleInvalidRedFlag: {
     type: 'red-flag',
@@ -24,6 +26,7 @@ export const records = {
     location: '50.68685499999992,3.89',
     title: 'need intervention',
     comment: 'more on the state of the nations roads',
+    emailNotify: false,
   },
 };
 

--- a/test/records.js
+++ b/test/records.js
@@ -275,6 +275,19 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           });
       });
 
+      it("Should not change notification setting on other's records", done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/1/emailnotify`)
+          .set('authorization', `Bearer ${adminToken}`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(403);
+            expect(body).to.have.property('errors');
+            done();
+          });
+      });
+
       it('Should succesfully update location of record with valid id', done => {
         chai
           .request(server)
@@ -326,7 +339,34 @@ export default ({ server, chai, expect, ROOT_URL }) => {
             done();
           });
       });
+
+      it('Should return success when notification setting patch equals original', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/1/emailnotify`)
+          .set('authorization', `Bearer ${authToken}`)
+          .send({ emailNotify: false })
+          .end((err, { status }) => {
+            expect(status).eq(304);
+            done();
+          });
+      });
+
+      it('Should succesfully update notification setting of record with valid id', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/red-flags/1/emailnotify`)
+          .set('authorization', `Bearer ${authToken}`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
+            done();
+          });
+      });
     });
+
     describe('Deletion', () => {
       it("Should not delete other's records", done => {
         chai
@@ -456,6 +496,19 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           });
       });
 
+      it("Should not change notification setting on other's records", done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/interventions/6/emailnotify`)
+          .set('authorization', `Bearer ${adminToken}`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(403);
+            expect(body).to.have.property('errors');
+            done();
+          });
+      });
+
       it('Should succesfully update comment of record with valid id', done => {
         chai
           .request(server)
@@ -504,6 +557,32 @@ export default ({ server, chai, expect, ROOT_URL }) => {
           .send(recordPatches)
           .end((err, { status }) => {
             expect(status).eq(304);
+            done();
+          });
+      });
+
+      it('Should return success when notification setting patch equals original', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}/interventions/6/emailnotify`)
+          .set('authorization', `Bearer ${authToken}`)
+          .send({ emailNotify: false })
+          .end((err, { status }) => {
+            expect(status).eq(304);
+            done();
+          });
+      });
+
+      it('Should succesfully update notification setting of record with valid id', done => {
+        chai
+          .request(server)
+          .patch(`${ROOT_URL}//interventions/6/emailnotify`)
+          .set('authorization', `Bearer ${authToken}`)
+          .send(recordPatches)
+          .end((err, { body, status }) => {
+            expect(status).eq(200);
+            expect(body).to.have.property('data');
+            expect(body.data[0]).to.have.property('message');
             done();
           });
       });
@@ -609,7 +688,7 @@ export default ({ server, chai, expect, ROOT_URL }) => {
         });
     });
 
-    it('Should not modify record location/comment when record status has been mutated', done => {
+    it('Should not modify record location/comment notification setting when record status has been mutated', done => {
       chai
         .request(server)
         .patch(`${ROOT_URL}/red-flags/2/location`)


### PR DESCRIPTION
**What does this PR do?**
Implements record editing from frontend and update backend to enable full fuctionality of this frontend integration.

**Description of Task to be completed?**
- Add endpoints on API server to toggle email notifications for individual records
- Improve param validation and type casts on the backend
- Fix route/controller mismatch
- Implement record comment/location/notification updating from frontend

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-frontend-record-editing-163281354`
- run `npm run devstart`

 Test record creation from user dashboard profile page by clicking on the edit record link on the record detail modal

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163281354](https://www.pivotaltracker.com/story/show/163281354)

Screenshots (if appropriate)

N/A

Questions:

N/A