### PR TITLE
#163458742 Implement record media fetching 

### DIFF
--- a/UI/assets/css/style.css
+++ b/UI/assets/css/style.css
@@ -758,11 +758,17 @@ a {
 }
 .record__image-holder {
   flex-grow: 0;
+  height: 20rem;
 }
 .record__image {
   display: block;
+  background-image: url(../images/Infinity-5.3s-200px.svg);
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
   object-fit: cover;
   width: 100%;
+  height: 100%;
 }
 .record__details {
   flex-grow: 1;
@@ -875,28 +881,40 @@ a {
 .detail-modal__map {
   height: 20rem;
 }
+.detail-modal__title-block {
+  margin-top: auto;
+}
+.detail-modal__title,
 .detail-modal__comment {
   margin-top: 1rem;
 }
-.detail-modal__title,
 .detail-modal__sub {
-  margin-top: 1rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
 }
 .detail-modal__media {
+  overflow-x: hidden;
+}
+.detail-modal__media-images {
+  margin-bottom: 1.5rem;
+}
+.detail-modal__media-images,
+.detail-modal__media-videos {
   display: grid;
-  grid-auto-flow: column;
   overflow-x: auto;
+  grid-auto-columns: 30rem;
+  grid-auto-flow: column;
   width: 100%;
-  overflow-y: hidden;
-  align-items: center;
   height: 18rem;
+  grid-gap: 2rem;
 }
 .detail-modal__media-item {
-  margin: 0.5rem;
   height: 100%;
+  width: 100%;
 }
 .detail-modal__content::-webkit-scrollbar,
-.detail-modal__media::-webkit-scrollbar {
+.detail-modal__media-images::-webkit-scrollbar,
+.detail-modal__media-videos::-webkit-scrollbar {
   display: none;
 }
 .detail-modal__status-toggle {
@@ -1003,8 +1021,13 @@ a {
   opacity: 1;
   visibility: visible;
 }
+
+/* helpers */
 .pushdown {
   margin: 1.5rem auto -1.5rem;
+}
+.remove {
+  display: none;
 }
 
 /* animation */
@@ -1211,9 +1234,6 @@ a {
   }
   .modal-wrapper * {
     font-size: larger;
-  }
-  .detail-modal__media {
-    height: 25rem;
   }
   .notification-wrapper {
     width: 30rem;

--- a/UI/assets/js/helpers.js
+++ b/UI/assets/js/helpers.js
@@ -1127,7 +1127,8 @@ const IR_HELPERS = {
     const recordTitle = modal.querySelector('.detail-modal__title');
     const recordByLine = modal.querySelector('.detail-modal__byline');
     const recordComment = modal.querySelector('.detail-modal__comment');
-    const recordMedia = modal.querySelector('.detail-modal__media');
+    const recordImages = modal.querySelector('.detail-modal__media-images');
+    const recordVideos = modal.querySelector('.detail-modal__media-videos');
     const recordEditBtn = document.querySelector('.detail-modal__edit');
     const {
       comment,
@@ -1137,11 +1138,15 @@ const IR_HELPERS = {
       status,
       title,
       type,
+      images,
+      videos,
     } = record;
+    const imageUrls = JSON.parse(images);
+    const videoUrls = JSON.parse(videos);
 
     modalHeader.textContent = `${IR_HELPERS.capitalize(type)}  #${id}`;
     if (!location) {
-      locationMap.style.display = 'none';
+      locationMap.classList.add('remove');
     } else {
       IR_HELPERS.initModalMap(
         IR_HELPERS.flipLocationString(location),
@@ -1153,15 +1158,35 @@ const IR_HELPERS = {
       recordByLine.innerHTML = `by: <a href="#">${username}</a>`;
     });
     recordComment.textContent = comment;
-    recordMedia.appendChild(
-      IR_HELPERS.spawnElement({
-        element: 'img',
-        attrs: {
-          src: '../assets/images/crashSite.jpeg',
-          class: 'detail-modal__media-item',
-        },
-      })
-    );
+
+    if (imageUrls.length) {
+      imageUrls.forEach(srcUrl => {
+        recordImages.appendChild(
+          IR_HELPERS.spawnElement({
+            element: 'img',
+            attrs: {
+              src: srcUrl,
+              class: 'detail-modal__media-item',
+            },
+          })
+        );
+      });
+    } else recordImages.classList.add('remove');
+
+    if (videoUrls.length) {
+      videoUrls.forEach(srcUrl => {
+        recordVideos.appendChild(
+          IR_HELPERS.spawnElement({
+            element: 'video',
+            attrs: {
+              src: srcUrl,
+              class: 'detail-modal__media-item',
+              controls: '',
+            },
+          })
+        );
+      });
+    } else recordVideos.classList.add('remove');
 
     if (recordEditBtn) {
       recordEditBtn.addEventListener('click', () =>
@@ -1193,16 +1218,21 @@ const IR_HELPERS = {
     const recordTitle = modal.querySelector('.detail-modal__title');
     const recordByLine = modal.querySelector('.detail-modal__byline');
     const recordComment = modal.querySelector('.detail-modal__comment');
-    const recordMedia = modal.querySelector('.detail-modal__media');
+    const recordImages = modal.querySelector('.detail-modal__media-images');
+    const recordVideos = modal.querySelector('.detail-modal__media-videos');
 
     [
       modalHeader,
       recordTitle,
       recordByLine,
       recordComment,
-      recordMedia,
+      recordImages,
+      recordVideos,
     ].forEach(element => IR_HELPERS.clearNode(element));
-    locationMap.style.display = 'block';
+
+    [locationMap, recordImages, recordVideos].forEach(element =>
+      element.classList.remove('remove')
+    );
 
     if (state.isAdmin) {
       const statusToggle = modal.querySelector('.detail-modal__status-toggle');
@@ -1218,18 +1248,20 @@ const IR_HELPERS = {
   recordsToFeedComponents(recArray, elementCreator) {
     const defaultImage = '../assets/images/crashSite.jpeg';
     if (!recArray) throw IR_HELPERS.errors.internal;
-    return recArray.map(
-      ({ type, id, imgUrl = defaultImage, status, title, comment }) =>
-        elementCreator({
-          element: 'div',
-          attrs: {
-            class: `record record--${type} record--${
-              status === 'under investigation' ? 'investigating' : status
-            }`,
-          },
-          inner: `
+
+    return recArray.map(({ type, id, images, status, title, comment }) =>
+      elementCreator({
+        element: 'div',
+        attrs: {
+          class: `record record--${type} record--${
+            status === 'under investigation' ? 'investigating' : status
+          }`,
+        },
+        inner: `
         <div class="record__image-holder">
-          <img class="record__image" src=${imgUrl} alt="crash site" >
+          <img class="record__image" src=${
+            JSON.parse(images).length ? JSON.parse(images)[0] : defaultImage
+          } alt="Report thumbnail" >
         </div>
         <div class="record__details">
           <h4 class="record__title">${title}</h4>
@@ -1241,7 +1273,7 @@ const IR_HELPERS = {
         </div>
         <button class="record__more-btn" record-path="${type}s/${id}">View More</button>
         `,
-        })
+      })
     );
   },
 

--- a/UI/views/admin.html
+++ b/UI/views/admin.html
@@ -87,6 +87,8 @@
         <div class="detail-modal__media-block">
           <h4 class="detail-modal__sub">Media</h4>
           <div class="detail-modal__media">
+            <div class="detail-modal__media-images"></div>
+            <div class="detail-modal__media-videos"></div>
           </div>
         </div>
         <div class="detail-modal__toggle-block">

--- a/UI/views/profile.html
+++ b/UI/views/profile.html
@@ -91,6 +91,8 @@
         <div class="detail-modal__media-block">
           <h4 class="detail-modal__sub">Media</h4>
           <div class="detail-modal__media">
+          <div class="detail-modal__media-images"></div>
+          <div class="detail-modal__media-videos"></div>
           </div>
         </div>
       </div>

--- a/UI/views/user.html
+++ b/UI/views/user.html
@@ -87,6 +87,8 @@
         <div class="detail-modal__media-block">
           <h4 class="detail-modal__sub">Media</h4>
           <div class="detail-modal__media">
+            <div class="detail-modal__media-images"></div>
+            <div class="detail-modal__media-videos"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
**What does this PR do?**
Retrieves record media from cloud storage for front-end rendering.

**Description of Task to be completed?**
- Fetch record thumbnail using source URL saved to the API server database or  fallback to a default image
- Display all media attachments for a single record in record detail view

**How should this be manually tested?**
- Clone this repository
- In your local copy checkout `ft-implement-record-media-fetching-163458742`
- Run `npm run devstart`
- Launch UI
- Create a few records with media attachments (images/videos).
Uploaded Image should be used as record thumbnail and all media displayed in record detail view

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[163458742](https://www.pivotaltracker.com/story/show/163458742)

Screenshots (if appropriate)

N/A

Questions:

N/A

